### PR TITLE
New type id system

### DIFF
--- a/scalaNextTests/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
+++ b/scalaNextTests/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
@@ -44,11 +44,11 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("i"),
                   Schema[Long].reflect.asTerm("l")
                 ),
-                typeName = TypeName(
+                typeId = TypeName.toTypeId(TypeName(
                   namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
                   name = "NamedTuple[b,sh,i,l]",
                   params = Seq(TypeName.byte, TypeName.short, TypeName.int, TypeName.long)
-                ),
+                )),
                 recordBinding = null
               )
             )
@@ -100,11 +100,11 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("i"),
                   Schema[String].reflect.asTerm("s")
                 ),
-                typeName = TypeName(
+                typeId = TypeName.toTypeId(TypeName(
                   namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
                   name = "NamedTuple[i,s]",
                   params = Seq(TypeName.int, TypeName.string)
-                ),
+                )),
                 recordBinding = null
               )
             )
@@ -128,14 +128,14 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema.derived[(Int, Long)].reflect.asTerm("i"),
                   Schema.derived[(String, String)].reflect.asTerm("s")
                 ),
-                typeName = TypeName(
+                typeId = TypeName.toTypeId(TypeName(
                   namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
                   name = "NamedTuple[i,s]",
                   params = Seq(
                     TypeName(Namespace.scala, "Tuple2", Seq(TypeName.int, TypeName.long)),
                     TypeName(Namespace.scala, "Tuple2", Seq(TypeName.string, TypeName.string))
                   )
-                ),
+                )),
                 recordBinding = null
               )
             )
@@ -149,11 +149,11 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Option[Int]].reflect.asTerm("i"),
                   Schema[Option[String]].reflect.asTerm("s")
                 ),
-                typeName = TypeName(
+                typeId = TypeName.toTypeId(TypeName(
                   namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
                   name = "NamedTuple[i,s]",
                   params = Seq(TypeName.option(TypeName.int), TypeName.option(TypeName.string))
-                ),
+                )),
                 recordBinding = null
               )
             )
@@ -164,7 +164,7 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
             new Schema[NamedTuple.Empty](
               reflect = Reflect.Record[Binding, NamedTuple.Empty](
                 fields = Vector(),
-                typeName = TypeName(Namespace(Seq("scala"), Seq("NamedTuple")), "NamedTuple[]"),
+                typeId = TypeName.toTypeId(TypeName(Namespace(Seq("scala"), Seq("NamedTuple")), "NamedTuple[]")),
                 recordBinding = null
               )
             )
@@ -211,11 +211,11 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("_1"),
                   Schema[String].reflect.asTerm("_2")
                 ),
-                typeName = TypeName(
+                typeId = TypeName.toTypeId(TypeName(
                   namespace = Namespace.scala,
                   name = "Tuple2",
                   params = Seq(TypeName.int, TypeName.string)
-                ),
+                )),
                 recordBinding = null
               )
             )
@@ -254,11 +254,11 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("a"),
                   Schema[String].reflect.asTerm("b")
                 ),
-                typeName = TypeName(
+                typeId = TypeName.toTypeId(TypeName(
                   namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
                   name = "NamedTuple[a,b]",
                   params = Seq(TypeName.int, TypeName.string)
-                ),
+                )),
                 recordBinding = null
               )
             )
@@ -292,11 +292,11 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[List[Int]].reflect.asTerm("a"),
                   Schema[Set[String]].reflect.asTerm("b")
                 ),
-                typeName = TypeName(
+                typeId = TypeName.toTypeId(TypeName(
                   namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
                   name = "NamedTuple[a,b]",
                   params = Seq(TypeName.list(TypeName.int), TypeName.set(TypeName.string))
-                ),
+                )),
                 recordBinding = null
               )
             )

--- a/scalaNextTests/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
+++ b/scalaNextTests/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
@@ -44,11 +44,13 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("i"),
                   Schema[Long].reflect.asTerm("l")
                 ),
-                typeId = TypeName.toTypeId(TypeName(
-                  namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
-                  name = "NamedTuple[b,sh,i,l]",
-                  params = Seq(TypeName.byte, TypeName.short, TypeName.int, TypeName.long)
-                )),
+                typeId = TypeName.toTypeId(
+                  TypeName(
+                    namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
+                    name = "NamedTuple[b,sh,i,l]",
+                    params = Seq(TypeName.byte, TypeName.short, TypeName.int, TypeName.long)
+                  )
+                ),
                 recordBinding = null
               )
             )
@@ -100,11 +102,13 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("i"),
                   Schema[String].reflect.asTerm("s")
                 ),
-                typeId = TypeName.toTypeId(TypeName(
-                  namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
-                  name = "NamedTuple[i,s]",
-                  params = Seq(TypeName.int, TypeName.string)
-                )),
+                typeId = TypeName.toTypeId(
+                  TypeName(
+                    namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
+                    name = "NamedTuple[i,s]",
+                    params = Seq(TypeName.int, TypeName.string)
+                  )
+                ),
                 recordBinding = null
               )
             )
@@ -128,14 +132,16 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema.derived[(Int, Long)].reflect.asTerm("i"),
                   Schema.derived[(String, String)].reflect.asTerm("s")
                 ),
-                typeId = TypeName.toTypeId(TypeName(
-                  namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
-                  name = "NamedTuple[i,s]",
-                  params = Seq(
-                    TypeName(Namespace.scala, "Tuple2", Seq(TypeName.int, TypeName.long)),
-                    TypeName(Namespace.scala, "Tuple2", Seq(TypeName.string, TypeName.string))
+                typeId = TypeName.toTypeId(
+                  TypeName(
+                    namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
+                    name = "NamedTuple[i,s]",
+                    params = Seq(
+                      TypeName(Namespace.scala, "Tuple2", Seq(TypeName.int, TypeName.long)),
+                      TypeName(Namespace.scala, "Tuple2", Seq(TypeName.string, TypeName.string))
+                    )
                   )
-                )),
+                ),
                 recordBinding = null
               )
             )
@@ -149,11 +155,13 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Option[Int]].reflect.asTerm("i"),
                   Schema[Option[String]].reflect.asTerm("s")
                 ),
-                typeId = TypeName.toTypeId(TypeName(
-                  namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
-                  name = "NamedTuple[i,s]",
-                  params = Seq(TypeName.option(TypeName.int), TypeName.option(TypeName.string))
-                )),
+                typeId = TypeName.toTypeId(
+                  TypeName(
+                    namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
+                    name = "NamedTuple[i,s]",
+                    params = Seq(TypeName.option(TypeName.int), TypeName.option(TypeName.string))
+                  )
+                ),
                 recordBinding = null
               )
             )
@@ -211,11 +219,13 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("_1"),
                   Schema[String].reflect.asTerm("_2")
                 ),
-                typeId = TypeName.toTypeId(TypeName(
-                  namespace = Namespace.scala,
-                  name = "Tuple2",
-                  params = Seq(TypeName.int, TypeName.string)
-                )),
+                typeId = TypeName.toTypeId(
+                  TypeName(
+                    namespace = Namespace.scala,
+                    name = "Tuple2",
+                    params = Seq(TypeName.int, TypeName.string)
+                  )
+                ),
                 recordBinding = null
               )
             )
@@ -254,11 +264,13 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("a"),
                   Schema[String].reflect.asTerm("b")
                 ),
-                typeId = TypeName.toTypeId(TypeName(
-                  namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
-                  name = "NamedTuple[a,b]",
-                  params = Seq(TypeName.int, TypeName.string)
-                )),
+                typeId = TypeName.toTypeId(
+                  TypeName(
+                    namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
+                    name = "NamedTuple[a,b]",
+                    params = Seq(TypeName.int, TypeName.string)
+                  )
+                ),
                 recordBinding = null
               )
             )
@@ -292,11 +304,13 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[List[Int]].reflect.asTerm("a"),
                   Schema[Set[String]].reflect.asTerm("b")
                 ),
-                typeId = TypeName.toTypeId(TypeName(
-                  namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
-                  name = "NamedTuple[a,b]",
-                  params = Seq(TypeName.list(TypeName.int), TypeName.set(TypeName.string))
-                )),
+                typeId = TypeName.toTypeId(
+                  TypeName(
+                    namespace = Namespace(Seq("scala"), Seq("NamedTuple")),
+                    name = "NamedTuple[a,b]",
+                    params = Seq(TypeName.list(TypeName.int), TypeName.set(TypeName.string))
+                  )
+                ),
                 recordBinding = null
               )
             )

--- a/schema-avro/src/main/scala/zio/blocks/schema/avro/AvroFormat.scala
+++ b/schema-avro/src/main/scala/zio/blocks/schema/avro/AvroFormat.scala
@@ -17,16 +17,16 @@ object AvroFormat
       new Deriver[AvroBinaryCodec] {
         override def derivePrimitive[F[_, _], A](
           primitiveType: PrimitiveType[A],
-          typeName: TypeName[A],
+          typeId: TypeId.OfType,
           binding: Binding[BindingType.Primitive, A],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect]
         ): Lazy[AvroBinaryCodec[A]] =
-          Lazy(deriveCodec(new Reflect.Primitive(primitiveType, typeName, binding, doc, modifiers)))
+          Lazy(deriveCodec(new Reflect.Primitive(primitiveType, typeId, binding, doc, modifiers)))
 
         override def deriveRecord[F[_, _], A](
           fields: IndexedSeq[Term[F, A, ?]],
-          typeName: TypeName[A],
+          typeId: TypeId.OfType,
           binding: Binding[BindingType.Record, A],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect]
@@ -34,7 +34,7 @@ object AvroFormat
           deriveCodec(
             new Reflect.Record(
               fields.asInstanceOf[IndexedSeq[Term[Binding, A, ?]]],
-              typeName,
+              typeId,
               binding,
               doc,
               modifiers
@@ -44,7 +44,7 @@ object AvroFormat
 
         override def deriveVariant[F[_, _], A](
           cases: IndexedSeq[Term[F, A, ?]],
-          typeName: TypeName[A],
+          typeId: TypeId.OfType,
           binding: Binding[BindingType.Variant, A],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect]
@@ -52,7 +52,7 @@ object AvroFormat
           deriveCodec(
             new Reflect.Variant(
               cases.asInstanceOf[IndexedSeq[Term[Binding, A, ? <: A]]],
-              typeName,
+              typeId,
               binding,
               doc,
               modifiers
@@ -62,20 +62,20 @@ object AvroFormat
 
         override def deriveSequence[F[_, _], C[_], A](
           element: Reflect[F, A],
-          typeName: TypeName[C[A]],
+          typeId: TypeId.OfType,
           binding: Binding[BindingType.Seq[C], C[A]],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect]
         )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[AvroBinaryCodec[C[A]]] = Lazy {
           deriveCodec(
-            new Reflect.Sequence(element.asInstanceOf[Reflect[Binding, A]], typeName, binding, doc, modifiers)
+            new Reflect.Sequence(element.asInstanceOf[Reflect[Binding, A]], typeId, binding, doc, modifiers)
           )
         }
 
         override def deriveMap[F[_, _], M[_, _], K, V](
           key: Reflect[F, K],
           value: Reflect[F, V],
-          typeName: TypeName[M[K, V]],
+          typeId: TypeId.OfType,
           binding: Binding[BindingType.Map[M], M[K, V]],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect]
@@ -84,7 +84,7 @@ object AvroFormat
             new Reflect.Map(
               key.asInstanceOf[Reflect[Binding, K]],
               value.asInstanceOf[Reflect[Binding, V]],
-              typeName,
+              typeId,
               binding,
               doc,
               modifiers
@@ -97,11 +97,11 @@ object AvroFormat
           doc: Doc,
           modifiers: Seq[Modifier.Reflect]
         )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[AvroBinaryCodec[DynamicValue]] =
-          Lazy(deriveCodec(new Reflect.Dynamic(binding, TypeName.dynamicValue, doc, modifiers)))
+          Lazy(deriveCodec(new Reflect.Dynamic(binding, TypeId.dynamicValue, doc, modifiers)))
 
         def deriveWrapper[F[_, _], A, B](
           wrapped: Reflect[F, B],
-          typeName: TypeName[A],
+          typeId: TypeId.OfType,
           wrapperPrimitiveType: Option[PrimitiveType[A]],
           binding: Binding[BindingType.Wrapper[A, B], A],
           doc: Doc,
@@ -110,7 +110,7 @@ object AvroFormat
           deriveCodec(
             new Reflect.Wrapper(
               wrapped.asInstanceOf[Reflect[Binding, B]],
-              typeName,
+              typeId,
               wrapperPrimitiveType,
               binding,
               doc,
@@ -134,8 +134,8 @@ object AvroFormat
         type TC[_]
 
         private[this] val recursiveRecordCache =
-          new ThreadLocal[java.util.HashMap[TypeName[?], (Array[AvroBinaryCodec[?]], AvroSchema)]] {
-            override def initialValue: java.util.HashMap[TypeName[?], (Array[AvroBinaryCodec[?]], AvroSchema)] =
+          new ThreadLocal[java.util.HashMap[TypeIdRepr, (Array[AvroBinaryCodec[?]], AvroSchema)]] {
+            override def initialValue: java.util.HashMap[TypeIdRepr, (Array[AvroBinaryCodec[?]], AvroSchema)] =
               new java.util.HashMap
           }
         private[this] val recordCounters =
@@ -1214,27 +1214,27 @@ object AvroFormat
               val binding              = record.recordBinding.asInstanceOf[Binding.Record[A]]
               val fields               = record.fields
               val isRecursive          = fields.exists(_.value.isInstanceOf[Reflect.Deferred[F, ?]])
-              val typeName             = record.typeName
+              val typeId               = record.typeId
               var codecsWithAvroSchema =
-                if (isRecursive) recursiveRecordCache.get.get(typeName)
+                if (isRecursive) recursiveRecordCache.get.get(typeId)
                 else null
               var offset = 0
               if (codecsWithAvroSchema eq null) {
                 val namespaceBuilder = new java.lang.StringBuilder()
-                val namespace        = typeName.namespace
-                namespace.packages.foreach { element =>
+                val owner            = typeId.owner
+                owner.packages.foreach { element =>
                   if (namespaceBuilder.length > 0) namespaceBuilder.append('.')
                   namespaceBuilder.append(element)
                 }
-                namespace.values.foreach { element =>
+                owner.values.foreach { element =>
                   if (namespaceBuilder.length > 0) namespaceBuilder.append('.')
                   namespaceBuilder.append(element)
                 }
-                val avroSchema = createAvroRecord(namespaceBuilder.toString, typeName.name)
+                val avroSchema = createAvroRecord(namespaceBuilder.toString, typeId.name)
                 val len        = fields.length
                 val codecs     = new Array[AvroBinaryCodec[?]](len)
                 codecsWithAvroSchema = (codecs, avroSchema)
-                if (isRecursive) recursiveRecordCache.get.put(typeName, codecsWithAvroSchema)
+                if (isRecursive) recursiveRecordCache.get.put(typeId, codecsWithAvroSchema)
                 val avroSchemaFields = new java.util.ArrayList[AvroSchema.Field](len)
                 var idx              = 0
                 while (idx < len) {

--- a/schema-avro/src/test/scala/zio/blocks/schema/avro/AvroFormatSpec.scala
+++ b/schema-avro/src/test/scala/zio/blocks/schema/avro/AvroFormatSpec.scala
@@ -999,7 +999,7 @@ object AvroFormatSpec extends ZIOSpecDefault {
     implicit val schema: Schema[Email] = new Schema(
       new Reflect.Wrapper[Binding, Email, String](
         Schema[String].reflect,
-        TypeName(Namespace(Seq("zio", "blocks", "avro"), Seq("AvroFormatSpec")), "Email"),
+        TypeName.toTypeId(TypeName(Namespace(Seq("zio", "blocks", "avro"), Seq("AvroFormatSpec")), "Email")),
         None,
         new Binding.Wrapper(
           {

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaVersionSpecific.scala
@@ -170,7 +170,7 @@ private object SchemaVersionSpecific {
     }
 
     def toReprTree(typeId: TypeIdRepr): Tree = {
-      val owner = typeId.owner
+      val owner  = typeId.owner
       val params = typeId.params.map { p =>
         q"new _root_.zio.blocks.schema.TypeParam(${toReprTree(p.id)})"
       }
@@ -455,8 +455,8 @@ private object SchemaVersionSpecific {
       } else if (isNonAbstractScalaClass(tpe)) {
         deriveSchemaForNonAbstractScalaClass(tpe)
       } else if (isZioPreludeNewtype(tpe)) {
-        val schema  = findImplicitOrDeriveSchema(zioPreludeNewtypeDealias(tpe))
-        val tpeId = toTree(typeId(tpe))
+        val schema = findImplicitOrDeriveSchema(zioPreludeNewtypeDealias(tpe))
+        val tpeId  = toTree(typeId(tpe))
         q"new Schema($schema.reflect.typeId($tpeId)).asInstanceOf[Schema[$tpe]]"
       } else cannotDeriveSchema(tpe)
 

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaVersionSpecific.scala
@@ -2,7 +2,6 @@ package zio.blocks.schema
 
 import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
 import zio.blocks.schema.binding.RegisterOffset
-import zio.blocks.schema.{TypeName => SchemaTypeName}
 import zio.blocks.schema.CommonMacroOps
 import scala.collection.immutable.ArraySeq
 import scala.collection.mutable
@@ -127,11 +126,11 @@ private object SchemaVersionSpecific {
         }
     )
 
-    val typeNameCache = new mutable.HashMap[Type, SchemaTypeName[?]]
+    val typeIdCache = new mutable.HashMap[Type, TypeId.OfType]
 
-    def typeName(tpe: Type): SchemaTypeName[?] = {
-      def calculateTypeName(tpe: Type): SchemaTypeName[?] =
-        if (tpe =:= typeOf[java.lang.String]) SchemaTypeName.string
+    def typeId(tpe: Type): TypeId.OfType = {
+      def calculateTypeId(tpe: Type): TypeId.OfType =
+        if (tpe =:= typeOf[java.lang.String]) TypeId.string
         else {
           var packages  = List.empty[String]
           var values    = List.empty[String]
@@ -152,29 +151,34 @@ private object SchemaVersionSpecific {
             if (owner.isPackage || owner.isPackageClass) packages = ownerName :: packages
             else values = ownerName :: values
           }
-          new SchemaTypeName(new Namespace(packages, values), name, typeArgs(tpe).map(typeName))
+          val params = typeArgs(tpe).map(t => new TypeParam(typeId(t)))
+          TypeId.unsafeTag[TypeId.KindTag.Type](new TypeIdRepr(new Owner(packages, values), name, params))
         }
 
-      typeNameCache.getOrElseUpdate(
+      typeIdCache.getOrElseUpdate(
         tpe,
         tpe match {
           case TypeRef(compTpe, typeSym, Nil) if typeSym.name.toString == "Type" =>
-            var tpeName = calculateTypeName(compTpe)
-            if (tpeName.name.endsWith(".type")) tpeName = tpeName.copy(name = tpeName.name.stripSuffix(".type"))
-            tpeName
-          case _ =>
-            calculateTypeName(tpe)
+            var id = calculateTypeId(compTpe)
+            if (id.name.endsWith(".type")) {
+              id = TypeId.unsafeTag[TypeId.KindTag.Type](id.copy(name = id.name.stripSuffix(".type")))
+            }
+            id
+          case _ => calculateTypeId(tpe)
         }
       )
     }
 
-    def toTree(tpeName: SchemaTypeName[?]): Tree = {
-      val packages = tpeName.namespace.packages.toList
-      val values   = tpeName.namespace.values.toList
-      val name     = tpeName.name
-      val params   = tpeName.params.map(toTree).toList
-      q"new TypeName(new Namespace($packages, $values), $name, $params)"
+    def toReprTree(typeId: TypeIdRepr): Tree = {
+      val owner = typeId.owner
+      val params = typeId.params.map { p =>
+        q"new _root_.zio.blocks.schema.TypeParam(${toReprTree(p.id)})"
+      }
+      q"new _root_.zio.blocks.schema.TypeIdRepr(new _root_.zio.blocks.schema.Owner(${owner.packages}, ${owner.values}), ${typeId.name}, _root_.scala.List(..$params))"
     }
+
+    def toTree(typeId: TypeId.OfType): Tree =
+      q"_root_.zio.blocks.schema.TypeId.unsafeTag[_root_.zio.blocks.schema.TypeId.KindTag.Type](${toReprTree(typeId)})"
 
     def modifiers(tpe: Type): List[Tree] = {
       val modifiers = new mutable.ListBuffer[Tree]
@@ -390,11 +394,13 @@ private object SchemaVersionSpecific {
                     new Builder(new Array[$elementTpe](sizeHint).asInstanceOf[Array[B]], 0)
                 }"""
             } else q"SeqConstructor.arrayConstructor"
-          val tpeName = toTree(typeName(tpe))
+          val tpeId = toTree(typeId(tpe))
           q"""new Schema(
               reflect = new Reflect.Sequence(
                 element = $schema.reflect,
-                typeName = $tpeName.copy(params = List($schema.reflect.typeName)),
+                typeId = _root_.zio.blocks.schema.TypeId.unsafeTag[_root_.zio.blocks.schema.TypeId.KindTag.Type](
+                  $tpeId.copy(params = _root_.scala.List(new _root_.zio.blocks.schema.TypeParam($schema.reflect.typeId)))
+                ),
                 seqBinding = new Binding.Seq(
                   constructor = $constructor,
                   deconstructor = SeqDeconstructor.arrayDeconstructor
@@ -450,16 +456,16 @@ private object SchemaVersionSpecific {
         deriveSchemaForNonAbstractScalaClass(tpe)
       } else if (isZioPreludeNewtype(tpe)) {
         val schema  = findImplicitOrDeriveSchema(zioPreludeNewtypeDealias(tpe))
-        val tpeName = toTree(typeName(tpe))
-        q"new Schema($schema.reflect.typeName($tpeName)).asInstanceOf[Schema[$tpe]]"
+        val tpeId = toTree(typeId(tpe))
+        q"new Schema($schema.reflect.typeId($tpeId)).asInstanceOf[Schema[$tpe]]"
       } else cannotDeriveSchema(tpe)
 
     def deriveSchemaForEnumOrModuleValue(tpe: Type): Tree = {
-      val tpeName = toTree(typeName(tpe))
+      val tpeId = toTree(typeId(tpe))
       q"""new Schema(
             reflect = new Reflect.Record[Binding, $tpe](
               fields = _root_.scala.Vector.empty,
-              typeName = $tpeName,
+              typeId = $tpeId,
               recordBinding = new Binding.Record(
                 constructor = new ConstantConstructor[$tpe](${tpe.typeSymbol.asClass.module}),
                 deconstructor = new ConstantDeconstructor[$tpe]
@@ -471,11 +477,11 @@ private object SchemaVersionSpecific {
 
     def deriveSchemaForNonAbstractScalaClass(tpe: Type): Tree = {
       val classInfo = new ClassInfo(tpe)
-      val tpeName   = toTree(typeName(tpe))
+      val tpeId     = toTree(typeId(tpe))
       q"""new Schema(
             reflect = new Reflect.Record[Binding, $tpe](
               fields = _root_.scala.Vector(..${classInfo.fields(tpe)}),
-              typeName = $tpeName,
+              typeId = $tpeId,
               recordBinding = new Binding.Record(
                 constructor = new Constructor[$tpe] {
                   def usedRegisters: RegisterOffset = ${classInfo.usedRegisters}
@@ -498,7 +504,7 @@ private object SchemaVersionSpecific {
     def deriveSchemaForSealedTraitOrAbstractClass(tpe: Type): Tree = {
       val subtypes = directSubTypes(tpe)
       if (subtypes.isEmpty) fail(s"Cannot find sub-types for ADT base '$tpe'.")
-      val fullTermNames         = subtypes.map(sTpe => toFullTermName(typeName(sTpe)))
+      val fullTermNames         = subtypes.map(sTpe => toFullTermName(typeId(sTpe)))
       val maxCommonPrefixLength = {
         val minFullTermName = fullTermNames.min
         val maxFullTermName = fullTermNames.max
@@ -531,11 +537,11 @@ private object SchemaVersionSpecific {
               }
             }"""
       }
-      val tpeName = toTree(typeName(tpe))
+      val tpeId = toTree(typeId(tpe))
       q"""new Schema(
             reflect = new Reflect.Variant[Binding, $tpe](
               cases = _root_.scala.Vector(..$cases),
-              typeName = $tpeName,
+              typeId = $tpeId,
               variantBinding = new Binding.Variant(
                 discriminator = new Discriminator[$tpe] {
                   def discriminate(a: $tpe): Int = a match {
@@ -549,10 +555,10 @@ private object SchemaVersionSpecific {
           )"""
     }
 
-    def toFullTermName(tpeName: SchemaTypeName[?]): Array[String] = {
-      val packages     = tpeName.namespace.packages
-      val values       = tpeName.namespace.values
-      val fullTermName = new Array[String](packages.size + values.size + 1)
+    def toFullTermName(typeId: TypeIdRepr): Array[String] = {
+      val packages     = typeId.owner.packages
+      val values       = typeId.owner.values
+      val fullTermName = new Array[String](packages.length + values.length + 1)
       var idx          = 0
       packages.foreach { p =>
         fullTermName(idx) = p
@@ -562,7 +568,7 @@ private object SchemaVersionSpecific {
         fullTermName(idx) = p
         idx += 1
       }
-      fullTermName(idx) = tpeName.name
+      fullTermName(idx) = typeId.name
       fullTermName
     }
 

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/TypeIdVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/TypeIdVersionSpecific.scala
@@ -1,0 +1,105 @@
+package zio.blocks.schema
+
+import scala.collection.mutable
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+import scala.reflect.NameTransformer
+
+trait TypeIdVersionSpecific {
+  def derive[A]: TypeId.OfType = macro TypeIdVersionSpecific.derive[A]
+}
+
+private object TypeIdVersionSpecific {
+  def derive[A: c.WeakTypeTag](c: blackbox.Context): c.Expr[TypeId.OfType] = {
+    import c.universe._
+    import c.internal._
+
+    def typeArgs(tpe: Type): List[Type] = CommonMacroOps.typeArgs(c)(tpe)
+
+    def companion(tpe: Type): Symbol = {
+      val comp = tpe.typeSymbol.companion
+      if (comp.isModule) comp
+      else {
+        val ownerChainOf = (s: Symbol) => Iterator.iterate(s)(_.owner).takeWhile(_ != NoSymbol).toArray.reverseIterator
+        val path         = ownerChainOf(tpe.typeSymbol)
+          .zipAll(ownerChainOf(enclosingOwner), NoSymbol, NoSymbol)
+          .dropWhile(x => x._1 == x._2)
+          .takeWhile(x => x._1 != NoSymbol)
+          .map(x => x._1.name.toTermName)
+        if (path.isEmpty) NoSymbol
+        else c.typecheck(path.foldLeft[Tree](Ident(path.next()))(Select(_, _)), silent = true).symbol
+      }
+    }
+
+    val anyTpe = definitions.AnyTpe
+
+    val cache = new mutable.HashMap[Type, TypeIdRepr]
+
+    def ownerAndName(tpe: Type): (Owner, String) = {
+      var packages = List.empty[String]
+      var values   = List.empty[String]
+      val tpeSym   = tpe.typeSymbol
+      var name     = NameTransformer.decode(tpeSym.name.toString)
+
+      val comp  = companion(tpe)
+      var owner =
+        if (comp == null) tpeSym
+        else if (comp == NoSymbol) {
+          name += ".type"
+          tpeSym.asClass.module
+        } else comp
+
+      while ({
+        owner = owner.owner
+        owner.owner != NoSymbol
+      }) {
+        val ownerName = NameTransformer.decode(owner.name.toString)
+        if (owner.isPackage || owner.isPackageClass) packages = ownerName :: packages
+        else values = ownerName :: values
+      }
+
+      (new Owner(packages, values), name)
+    }
+
+    def typeIdRepr(tpe0: Type, nested: List[Type]): TypeIdRepr = {
+      val tpe = tpe0 match {
+        case TypeRef(compTpe, typeSym, Nil) if typeSym.name.toString == "Type" => compTpe
+        case other                                                             => other
+      }
+
+      cache.getOrElseUpdate(
+        tpe, {
+          val (owner, name) =
+            if (tpe =:= typeOf[java.lang.String]) (Owner.fromNamespace(Namespace.scala), "String")
+            else ownerAndName(tpe)
+
+          val params = typeArgs(tpe).map { arg =>
+            val argId =
+              if (nested.contains(arg)) typeIdRepr(anyTpe, Nil)
+              else typeIdRepr(arg, arg :: nested)
+            new TypeParam(argId)
+          }
+
+          new TypeIdRepr(owner, name, params)
+        }
+      )
+    }
+
+    def toTree(repr: TypeIdRepr): Tree = {
+      def ownerTree(owner: Owner): Tree =
+        q"new _root_.zio.blocks.schema.Owner(${owner.packages}, ${owner.values})"
+
+      def paramTree(p: TypeParam): Tree =
+        q"new _root_.zio.blocks.schema.TypeParam(${toTree(p.id)})"
+
+      q"new _root_.zio.blocks.schema.TypeIdRepr(${ownerTree(repr.owner)}, ${repr.name}, _root_.scala.List(..${repr.params.map(paramTree)}))"
+    }
+
+    val reprTree = toTree(typeIdRepr(weakTypeOf[A].dealias, Nil))
+
+    c.Expr[TypeId.OfType](
+      q"_root_.zio.blocks.schema.TypeId.unsafeTag[_root_.zio.blocks.schema.TypeId.KindTag.Type]($reprTree)"
+    )
+  }
+}
+

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/TypeIdVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/TypeIdVersionSpecific.scala
@@ -102,4 +102,3 @@ private object TypeIdVersionSpecific {
     )
   }
 }
-

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaVersionSpecific.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaVersionSpecific.scala
@@ -800,8 +800,8 @@ private class SchemaVersionSpecificImpl(using Quotes) {
           val typeInfo =
             if (isGenericTuple(tTpe)) new GenericTupleInfo[tt](tTpe)
             else new ClassInfo[tt](tTpe)
-          val fields  = typeInfo.fields[tt](Array.empty[String])
-          val tpeId = toExpr(typeId(tTpe))
+          val fields = typeInfo.fields[tt](Array.empty[String])
+          val tpeId  = toExpr(typeId(tTpe))
           '{
             new Schema(
               reflect = new Reflect.Record[Binding, tt](
@@ -870,8 +870,8 @@ private class SchemaVersionSpecificImpl(using Quotes) {
           val typeInfo =
             if (isGenericTuple(tTpe)) new GenericTupleInfo[tt](tTpe)
             else new ClassInfo[tt](tTpe)
-          val fields  = typeInfo.fields[T](nameOverrides)
-          val tpeId = toExpr(typeId(tpe))
+          val fields = typeInfo.fields[T](nameOverrides)
+          val tpeId  = toExpr(typeId(tpe))
           '{
             new Schema(
               reflect = new Reflect.Record[Binding, T](

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaVersionSpecific.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaVersionSpecific.scala
@@ -210,11 +210,11 @@ private class SchemaVersionSpecificImpl(using Quotes) {
         }
     )
 
-  private val typeNameCache = new mutable.HashMap[TypeRepr, TypeName[?]]
+  private val typeIdCache = new mutable.HashMap[TypeRepr, TypeId.OfType]
 
-  private def typeName[T: Type](tpe: TypeRepr, nestedTpes: List[TypeRepr] = Nil): TypeName[T] = {
-    def calculateTypeName(tpe: TypeRepr): TypeName[?] =
-      if (tpe =:= TypeRepr.of[java.lang.String]) TypeName.string
+  private def typeId(tpe: TypeRepr, nestedTpes: List[TypeRepr] = Nil): TypeId.OfType = {
+    def calculateTypeId(tpe: TypeRepr): TypeId.OfType =
+      if (tpe =:= TypeRepr.of[java.lang.String]) TypeId.string
       else {
         var packages: List[String] = Nil
         var values: List[String]   = Nil
@@ -260,36 +260,43 @@ private class SchemaVersionSpecificImpl(using Quotes) {
             else typeArgs(tTpe)
           } else if (isGenericTuple(tpe)) genericTupleTypeArgs(tpe)
           else typeArgs(tpe)
-        new TypeName(
-          new Namespace(packages, values),
-          name,
-          tpeTypeArgs.map { x =>
-            if (nestedTpes.contains(x)) typeName[Any](anyTpe)
-            else typeName(x, x :: nestedTpes)
-          }
+        TypeId.unsafeTag[TypeId.KindTag.Type](
+          new TypeIdRepr(
+            new Owner(packages, values),
+            name,
+            tpeTypeArgs.map { x =>
+              val argId =
+                if (nestedTpes.contains(x)) typeId(anyTpe)
+                else typeId(x, x :: nestedTpes)
+              new TypeParam(argId)
+            }
+          )
         )
       }
 
-    typeNameCache
+    typeIdCache
       .getOrElseUpdate(
         tpe,
-        calculateTypeName(tpe match {
+        calculateTypeId(tpe match {
           case TypeRef(compTpe, "Type") => compTpe
           case _                        => tpe
         })
       )
-      .asInstanceOf[TypeName[T]]
   }
 
-  private def toExpr[T: Type](tpeName: TypeName[T])(using Quotes): Expr[TypeName[T]] = {
-    val packages = Varargs(tpeName.namespace.packages.map(Expr(_)))
-    val vs       = tpeName.namespace.values
-    val values   = if (vs.isEmpty) '{ Nil } else Varargs(vs.map(Expr(_)))
-    val name     = Expr(tpeName.name)
-    val ps       = tpeName.params
-    val params   = if (ps.isEmpty) '{ Nil } else Varargs(ps.map(param => toExpr(param.asInstanceOf[TypeName[T]])))
-    '{ new TypeName[T](new Namespace($packages, $values), $name, $params) }
+  private def toExprRepr(repr: TypeIdRepr)(using Quotes): Expr[TypeIdRepr] = {
+    def ownerExpr(owner: Owner): Expr[Owner] =
+      '{ new Owner(${ Expr(owner.packages) }, ${ Expr(owner.values) }) }
+
+    def paramExpr(p: TypeParam): Expr[TypeParam] =
+      '{ new TypeParam(${ toExprRepr(p.id) }) }
+
+    val params: Expr[List[TypeParam]] = Expr.ofList(repr.params.map(paramExpr))
+    '{ new TypeIdRepr(${ ownerExpr(repr.owner) }, ${ Expr(repr.name) }, $params) }
   }
+
+  private def toExpr(typeId: TypeId.OfType)(using Quotes): Expr[TypeId.OfType] =
+    '{ ${ toExprRepr(typeId) }.asInstanceOf[TypeId.OfType] }
 
   private def doc(tpe: TypeRepr)(using Quotes): Expr[Doc] = {
     if (isEnumValue(tpe)) tpe.termSymbol
@@ -682,12 +689,14 @@ private class SchemaVersionSpecificImpl(using Quotes) {
                   }
                 }
               } else '{ SeqConstructor.arrayConstructor }
-            val tpeName = toExpr(typeName[Array[et]](tpe))
+            val tpeId = toExpr(typeId(tpe))
             '{
               new Schema(
                 reflect = new Reflect.Sequence(
                   element = $schema.reflect,
-                  typeName = $tpeName.copy(params = List($schema.reflect.typeName)),
+                  typeId = $tpeId
+                    .copy(params = List(new TypeParam($schema.reflect.typeId)))
+                    .asInstanceOf[TypeId.OfType],
                   seqBinding = new Binding.Seq(
                     constructor = $constructor,
                     deconstructor = SeqDeconstructor.arrayDeconstructor
@@ -712,12 +721,14 @@ private class SchemaVersionSpecificImpl(using Quotes) {
                   }
                 }
               } else '{ SeqConstructor.iArrayConstructor }
-            val tpeName = toExpr(typeName[IArray[et]](tpe))
+            val tpeId = toExpr(typeId(tpe))
             '{
               new Schema(
                 reflect = new Reflect.Sequence(
                   element = $schema.reflect,
-                  typeName = $tpeName.copy(params = List($schema.reflect.typeName)),
+                  typeId = $tpeId
+                    .copy(params = List(new TypeParam($schema.reflect.typeId)))
+                    .asInstanceOf[TypeId.OfType],
                   seqBinding = new Binding.Seq(
                     constructor = $constructor,
                     deconstructor = SeqDeconstructor.iArrayDeconstructor
@@ -790,12 +801,12 @@ private class SchemaVersionSpecificImpl(using Quotes) {
             if (isGenericTuple(tTpe)) new GenericTupleInfo[tt](tTpe)
             else new ClassInfo[tt](tTpe)
           val fields  = typeInfo.fields[tt](Array.empty[String])
-          val tpeName = toExpr(typeName[tt](tTpe))
+          val tpeId = toExpr(typeId(tTpe))
           '{
             new Schema(
               reflect = new Reflect.Record[Binding, tt](
                 fields = Vector($fields*),
-                typeName = $tpeName,
+                typeId = $tpeId,
                 recordBinding = new Binding.Record(
                   constructor = new Constructor[tt] {
                     def usedRegisters: RegisterOffset = ${ typeInfo.usedRegisters }
@@ -860,12 +871,12 @@ private class SchemaVersionSpecificImpl(using Quotes) {
             if (isGenericTuple(tTpe)) new GenericTupleInfo[tt](tTpe)
             else new ClassInfo[tt](tTpe)
           val fields  = typeInfo.fields[T](nameOverrides)
-          val tpeName = toExpr(typeName[T](tpe))
+          val tpeId = toExpr(typeId(tpe))
           '{
             new Schema(
               reflect = new Reflect.Record[Binding, T](
                 fields = Vector($fields*),
-                typeName = $tpeName,
+                typeId = $tpeId,
                 recordBinding = new Binding.Record(
                   constructor = new Constructor {
                     def usedRegisters: RegisterOffset = ${ typeInfo.usedRegisters }
@@ -896,17 +907,17 @@ private class SchemaVersionSpecificImpl(using Quotes) {
       val sTpe = opaqueDealias(tpe)
       sTpe.asType match {
         case '[s] =>
-          val schema  = findImplicitOrDeriveSchema[s](sTpe)
-          val tpeName = toExpr(typeName[T](tpe).asInstanceOf[TypeName[s]])
-          '{ new Schema($schema.reflect.typeName($tpeName)).asInstanceOf[Schema[T]] }
+          val schema = findImplicitOrDeriveSchema[s](sTpe)
+          val tpeId  = toExpr(typeId(tpe))
+          '{ new Schema($schema.reflect.typeId($tpeId)).asInstanceOf[Schema[T]] }
       }
     } else if (isZioPreludeNewtype(tpe)) {
       val sTpe = zioPreludeNewtypeDealias(tpe)
       sTpe.asType match {
         case '[s] =>
-          val schema  = findImplicitOrDeriveSchema[s](sTpe)
-          val tpeName = toExpr(typeName[T](tpe).asInstanceOf[TypeName[s]])
-          '{ new Schema($schema.reflect.typeName($tpeName)).asInstanceOf[Schema[T]] }
+          val schema = findImplicitOrDeriveSchema[s](sTpe)
+          val tpeId  = toExpr(typeId(tpe))
+          '{ new Schema($schema.reflect.typeId($tpeId)).asInstanceOf[Schema[T]] }
       }
     } else if (isTypeRef(tpe)) {
       val sTpe = typeRefDealias(tpe)
@@ -915,12 +926,12 @@ private class SchemaVersionSpecificImpl(using Quotes) {
   }.asInstanceOf[Expr[Schema[T]]]
 
   private def deriveSchemaForEnumOrModuleValue[T: Type](tpe: TypeRepr)(using Quotes): Expr[Schema[T]] = {
-    val tpeName = toExpr(typeName(tpe))
+    val tpeId = toExpr(typeId(tpe))
     '{
       new Schema(
         reflect = new Reflect.Record[Binding, T](
           fields = Vector.empty,
-          typeName = $tpeName,
+          typeId = $tpeId,
           recordBinding = new Binding.Record(
             constructor = new ConstantConstructor(${
               Ref(
@@ -940,12 +951,12 @@ private class SchemaVersionSpecificImpl(using Quotes) {
   private def deriveSchemaForNonAbstractScalaClass[T: Type](tpe: TypeRepr)(using Quotes): Expr[Schema[T]] = {
     val classInfo = new ClassInfo(tpe)
     val fields    = classInfo.fields(Array.empty[String])
-    val tpeName   = toExpr(typeName(tpe))
+    val tpeId     = toExpr(typeId(tpe))
     '{
       new Schema(
         reflect = new Reflect.Record[Binding, T](
           fields = Vector($fields*),
-          typeName = $tpeName,
+          typeId = $tpeId,
           recordBinding = new Binding.Record(
             constructor = new Constructor {
               def usedRegisters: RegisterOffset = ${ classInfo.usedRegisters }
@@ -976,7 +987,7 @@ private class SchemaVersionSpecificImpl(using Quotes) {
       if (isUnion(tpe)) allUnionTypes(tpe)
       else directSubTypes(tpe)
     if (subtypes.isEmpty) fail(s"Cannot find sub-types for ADT base '${tpe.show}'.")
-    val fullTermNames         = subtypes.map(sTpe => toFullTermName(typeName(sTpe)))
+    val fullTermNames         = subtypes.map(sTpe => toFullTermName(typeId(sTpe)))
     val maxCommonPrefixLength = {
       val minFullTermName = fullTermNames.min
       val maxFullTermName = fullTermNames.max
@@ -1016,12 +1027,12 @@ private class SchemaVersionSpecificImpl(using Quotes) {
           }.asInstanceOf[Expr[Matcher[? <: T]]]
       }
     })
-    val tpeName = toExpr(typeName(tpe))
+    val tpeId = toExpr(typeId(tpe))
     '{
       new Schema(
         reflect = new Reflect.Variant[Binding, T](
           cases = Vector($cases*),
-          typeName = $tpeName,
+          typeId = $tpeId,
           variantBinding = new Binding.Variant(
             discriminator = new Discriminator {
               def discriminate(a: T): Int = ${
@@ -1046,10 +1057,10 @@ private class SchemaVersionSpecificImpl(using Quotes) {
     }
   }
 
-  private def toFullTermName(tpeName: TypeName[?]): Array[String] = {
-    val packages     = tpeName.namespace.packages
-    val values       = tpeName.namespace.values
-    val fullTermName = new Array[String](packages.size + values.size + 1)
+  private def toFullTermName(typeId: TypeIdRepr): Array[String] = {
+    val packages     = typeId.owner.packages
+    val values       = typeId.owner.values
+    val fullTermName = new Array[String](packages.length + values.length + 1)
     var idx          = 0
     packages.foreach { p =>
       fullTermName(idx) = p
@@ -1059,7 +1070,7 @@ private class SchemaVersionSpecificImpl(using Quotes) {
       fullTermName(idx) = p
       idx += 1
     }
-    fullTermName(idx) = tpeName.name
+    fullTermName(idx) = typeId.name
     fullTermName
   }
 

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/TypeIdVersionSpecific.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/TypeIdVersionSpecific.scala
@@ -1,0 +1,134 @@
+package zio.blocks.schema
+
+import scala.collection.mutable
+import scala.quoted.*
+
+trait TypeIdVersionSpecific {
+  inline def derive[A]: TypeId.OfType = ${ TypeIdVersionSpecificImpl.derive[A] }
+}
+
+private object TypeIdVersionSpecificImpl {
+  def derive[A: Type](using Quotes): Expr[TypeId.OfType] =
+    new TypeIdVersionSpecificImpl().derive[A]
+}
+
+private final class TypeIdVersionSpecificImpl(using Quotes) {
+  import quotes.reflect.*
+
+  private val anyTpe = defn.AnyClass.typeRef
+
+  private val cache = new mutable.HashMap[TypeRepr, TypeIdRepr]
+
+  private def isUnion(tpe: TypeRepr): Boolean = CommonMacroOps.isUnion(tpe)
+
+  private def allUnionTypes(tpe: TypeRepr): List[TypeRepr] = CommonMacroOps.allUnionTypes(tpe)
+
+  private def typeArgs(tpe: TypeRepr): List[TypeRepr] = CommonMacroOps.typeArgs(tpe)
+
+  private def isGenericTuple(tpe: TypeRepr): Boolean = CommonMacroOps.isGenericTuple(tpe)
+
+  private def genericTupleTypeArgs(tpe: TypeRepr): List[TypeRepr] = CommonMacroOps.genericTupleTypeArgs(tpe)
+
+  private def isNamedTuple(tpe: TypeRepr): Boolean = tpe match {
+    case AppliedType(ntTpe, _) => ntTpe.typeSymbol.fullName == "scala.NamedTuple$.NamedTuple"
+    case _                     => false
+  }
+
+  private def ownerAndName(tpe: TypeRepr): (Owner, String) = {
+    var packages: List[String] = Nil
+    var values: List[String]   = Nil
+    var name: String           = null
+
+    val tpeTypeSymbol = tpe.typeSymbol
+    name = tpeTypeSymbol.name
+
+    if (tpeTypeSymbol.flags.is(Flags.Module)) name = name.stripSuffix("$")
+
+    var owner = tpeTypeSymbol.owner
+    while (owner != defn.RootClass) {
+      val ownerName = owner.name
+      if (owner.flags.is(Flags.Package)) packages = ownerName :: packages
+      else if (owner.flags.is(Flags.Module)) values = ownerName.stripSuffix("$") :: values
+      else values = ownerName :: values
+      owner = owner.owner
+    }
+
+    (new Owner(packages, values), name)
+  }
+
+  private def typeIdRepr(tpe0: TypeRepr, nested: List[TypeRepr]): TypeIdRepr = {
+    val tpe = tpe0 match {
+      // zio-prelude newtype representation in Scala 3 (same as Schema derivation logic)
+      case TypeRef(compTpe, "Type") => compTpe
+      case other                    => other
+    }
+
+    cache.getOrElseUpdate(
+      tpe, {
+        if (tpe =:= TypeRepr.of[java.lang.String]) {
+          new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "String", Nil)
+        } else {
+          val isUnionTpe = isUnion(tpe)
+
+          val (owner, baseName) =
+            if (isUnionTpe) (Owner.root, "|")
+            else ownerAndName(tpe)
+
+          var name = baseName
+
+          val tpeTypeArgs: List[TypeRepr] =
+            if (isUnionTpe) allUnionTypes(tpe)
+            else if (isNamedTuple(tpe)) {
+              val tpeTypeArgs = typeArgs(tpe)
+              val nTpe        = tpeTypeArgs.head
+              val tTpe        = tpeTypeArgs.last
+              val nTypeArgs =
+                if (isGenericTuple(nTpe)) genericTupleTypeArgs(nTpe)
+                else typeArgs(nTpe)
+
+              var comma  = false
+              val labels = new java.lang.StringBuilder(name)
+              labels.append('[')
+              nTypeArgs.foreach { case ConstantType(StringConstant(str)) =>
+                if (comma) labels.append(',')
+                else comma = true
+                labels.append(str)
+              }
+              labels.append(']')
+              name = labels.toString
+
+              if (isGenericTuple(tTpe)) genericTupleTypeArgs(tTpe)
+              else typeArgs(tTpe)
+            } else if (isGenericTuple(tpe)) genericTupleTypeArgs(tpe)
+            else typeArgs(tpe)
+
+          val params = tpeTypeArgs.map { arg =>
+            val argId =
+              if (nested.contains(arg)) typeIdRepr(anyTpe, Nil)
+              else typeIdRepr(arg, arg :: nested)
+            new TypeParam(argId)
+          }
+
+          new TypeIdRepr(owner, name, params)
+        }
+      }
+    )
+  }
+
+  private def toExpr(repr: TypeIdRepr): Expr[TypeIdRepr] = {
+    def ownerExpr(owner: Owner): Expr[Owner] =
+      '{ new Owner(${ Expr(owner.packages) }, ${ Expr(owner.values) }) }
+
+    def paramExpr(p: TypeParam): Expr[TypeParam] =
+      '{ new TypeParam(${ toExpr(p.id) }) }
+
+    val ps: Expr[List[TypeParam]] = Expr.ofList(repr.params.map(paramExpr))
+    '{ new TypeIdRepr(${ ownerExpr(repr.owner) }, ${ Expr(repr.name) }, $ps) }
+  }
+
+  def derive[A: Type]: Expr[TypeId.OfType] = {
+    val repr = typeIdRepr(TypeRepr.of[A].dealias, Nil)
+    '{ ${ toExpr(repr) }.asInstanceOf[TypeId.OfType] }
+  }
+}
+

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/TypeIdVersionSpecific.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/TypeIdVersionSpecific.scala
@@ -64,53 +64,52 @@ private final class TypeIdVersionSpecificImpl(using Quotes) {
     }
 
     cache.getOrElseUpdate(
-      tpe, {
-        if (tpe =:= TypeRepr.of[java.lang.String]) {
-          new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "String", Nil)
-        } else {
-          val isUnionTpe = isUnion(tpe)
+      tpe,
+      if (tpe =:= TypeRepr.of[java.lang.String]) {
+        new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "String", Nil)
+      } else {
+        val isUnionTpe = isUnion(tpe)
 
-          val (owner, baseName) =
-            if (isUnionTpe) (Owner.root, "|")
-            else ownerAndName(tpe)
+        val (owner, baseName) =
+          if (isUnionTpe) (Owner.root, "|")
+          else ownerAndName(tpe)
 
-          var name = baseName
+        var name = baseName
 
-          val tpeTypeArgs: List[TypeRepr] =
-            if (isUnionTpe) allUnionTypes(tpe)
-            else if (isNamedTuple(tpe)) {
-              val tpeTypeArgs = typeArgs(tpe)
-              val nTpe        = tpeTypeArgs.head
-              val tTpe        = tpeTypeArgs.last
-              val nTypeArgs =
-                if (isGenericTuple(nTpe)) genericTupleTypeArgs(nTpe)
-                else typeArgs(nTpe)
+        val tpeTypeArgs: List[TypeRepr] =
+          if (isUnionTpe) allUnionTypes(tpe)
+          else if (isNamedTuple(tpe)) {
+            val tpeTypeArgs = typeArgs(tpe)
+            val nTpe        = tpeTypeArgs.head
+            val tTpe        = tpeTypeArgs.last
+            val nTypeArgs   =
+              if (isGenericTuple(nTpe)) genericTupleTypeArgs(nTpe)
+              else typeArgs(nTpe)
 
-              var comma  = false
-              val labels = new java.lang.StringBuilder(name)
-              labels.append('[')
-              nTypeArgs.foreach { case ConstantType(StringConstant(str)) =>
-                if (comma) labels.append(',')
-                else comma = true
-                labels.append(str)
-              }
-              labels.append(']')
-              name = labels.toString
+            var comma  = false
+            val labels = new java.lang.StringBuilder(name)
+            labels.append('[')
+            nTypeArgs.foreach { case ConstantType(StringConstant(str)) =>
+              if (comma) labels.append(',')
+              else comma = true
+              labels.append(str)
+            }
+            labels.append(']')
+            name = labels.toString
 
-              if (isGenericTuple(tTpe)) genericTupleTypeArgs(tTpe)
-              else typeArgs(tTpe)
-            } else if (isGenericTuple(tpe)) genericTupleTypeArgs(tpe)
-            else typeArgs(tpe)
+            if (isGenericTuple(tTpe)) genericTupleTypeArgs(tTpe)
+            else typeArgs(tTpe)
+          } else if (isGenericTuple(tpe)) genericTupleTypeArgs(tpe)
+          else typeArgs(tpe)
 
-          val params = tpeTypeArgs.map { arg =>
-            val argId =
-              if (nested.contains(arg)) typeIdRepr(anyTpe, Nil)
-              else typeIdRepr(arg, arg :: nested)
-            new TypeParam(argId)
-          }
-
-          new TypeIdRepr(owner, name, params)
+        val params = tpeTypeArgs.map { arg =>
+          val argId =
+            if (nested.contains(arg)) typeIdRepr(anyTpe, Nil)
+            else typeIdRepr(arg, arg :: nested)
+          new TypeParam(argId)
         }
+
+        new TypeIdRepr(owner, name, params)
       }
     )
   }
@@ -131,4 +130,3 @@ private final class TypeIdVersionSpecificImpl(using Quotes) {
     '{ ${ toExpr(repr) }.asInstanceOf[TypeId.OfType] }
   }
 }
-

--- a/schema/shared/src/main/scala/zio/blocks/schema/Owner.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Owner.scala
@@ -3,8 +3,8 @@ package zio.blocks.schema
 /**
  * Runtime owner information for a type identifier.
  *
- * This is intentionally "boring": it captures the package path and the chain
- * of enclosing values / types (e.g. objects) as strings.
+ * This is intentionally "boring": it captures the package path and the chain of
+ * enclosing values / types (e.g. objects) as strings.
  */
 final case class Owner(packages: List[String], values: List[String] = Nil) {
   lazy val elements: List[String] = packages ::: values

--- a/schema/shared/src/main/scala/zio/blocks/schema/Owner.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Owner.scala
@@ -1,0 +1,21 @@
+package zio.blocks.schema
+
+/**
+ * Runtime owner information for a type identifier.
+ *
+ * This is intentionally "boring": it captures the package path and the chain
+ * of enclosing values / types (e.g. objects) as strings.
+ */
+final case class Owner(packages: List[String], values: List[String] = Nil) {
+  lazy val elements: List[String] = packages ::: values
+}
+
+object Owner {
+  val root: Owner = new Owner(Nil, Nil)
+
+  private[schema] def fromNamespace(namespace: Namespace): Owner =
+    new Owner(namespace.packages.toList, namespace.values.toList)
+
+  private[schema] def toNamespace(owner: Owner): Namespace =
+    new Namespace(owner.packages, owner.values)
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/PrimitiveType.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/PrimitiveType.scala
@@ -11,7 +11,11 @@ sealed trait PrimitiveType[A] {
 
   def toDynamicValue(value: A): DynamicValue
 
-  def typeName: TypeName[A]
+  def typeId: TypeId.OfType
+
+  // Backwards-compatible TypeName view.
+  final def typeName: TypeName[A] =
+    TypeName.fromTypeId[A](typeId)
 
   def validation: Validation[A]
 }
@@ -22,7 +26,7 @@ object PrimitiveType {
 
     def toDynamicValue(value: scala.Unit): DynamicValue = new DynamicValue.Primitive(PrimitiveValue.Unit)
 
-    def typeName: TypeName[scala.Unit] = TypeName.unit
+    def typeId: TypeId.OfType = TypeId.unit
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -38,7 +42,7 @@ object PrimitiveType {
     def toDynamicValue(value: scala.Boolean): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.Boolean(value))
 
-    def typeName: TypeName[scala.Boolean] = TypeName.boolean
+    def typeId: TypeId.OfType = TypeId.boolean
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -53,7 +57,7 @@ object PrimitiveType {
   case class Byte(validation: Validation[scala.Byte]) extends PrimitiveType[scala.Byte] {
     def toDynamicValue(value: scala.Byte): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Byte(value))
 
-    def typeName: TypeName[scala.Byte] = TypeName.byte
+    def typeId: TypeId.OfType = TypeId.byte
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -68,7 +72,7 @@ object PrimitiveType {
   case class Short(validation: Validation[scala.Short]) extends PrimitiveType[scala.Short] {
     def toDynamicValue(value: scala.Short): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Short(value))
 
-    def typeName: TypeName[scala.Short] = TypeName.short
+    def typeId: TypeId.OfType = TypeId.short
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -83,7 +87,7 @@ object PrimitiveType {
   case class Int(validation: Validation[scala.Int]) extends PrimitiveType[scala.Int] {
     def toDynamicValue(value: scala.Int): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Int(value))
 
-    def typeName: TypeName[scala.Int] = TypeName.int
+    def typeId: TypeId.OfType = TypeId.int
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -98,7 +102,7 @@ object PrimitiveType {
   case class Long(validation: Validation[scala.Long]) extends PrimitiveType[scala.Long] {
     def toDynamicValue(value: scala.Long): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Long(value))
 
-    def typeName: TypeName[scala.Long] = TypeName.long
+    def typeId: TypeId.OfType = TypeId.long
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -113,7 +117,7 @@ object PrimitiveType {
   case class Float(validation: Validation[scala.Float]) extends PrimitiveType[scala.Float] {
     def toDynamicValue(value: scala.Float): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Float(value))
 
-    def typeName: TypeName[scala.Float] = TypeName.float
+    def typeId: TypeId.OfType = TypeId.float
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -128,7 +132,7 @@ object PrimitiveType {
   case class Double(validation: Validation[scala.Double]) extends PrimitiveType[scala.Double] {
     def toDynamicValue(value: scala.Double): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Double(value))
 
-    def typeName: TypeName[scala.Double] = TypeName.double
+    def typeId: TypeId.OfType = TypeId.double
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -143,7 +147,7 @@ object PrimitiveType {
   case class Char(validation: Validation[scala.Char]) extends PrimitiveType[scala.Char] {
     def toDynamicValue(value: scala.Char): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Char(value))
 
-    def typeName: TypeName[scala.Char] = TypeName.char
+    def typeId: TypeId.OfType = TypeId.char
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -159,7 +163,7 @@ object PrimitiveType {
     def toDynamicValue(value: Predef.String): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.String(value))
 
-    def typeName: TypeName[Predef.String] = TypeName.string
+    def typeId: TypeId.OfType = TypeId.string
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -174,7 +178,7 @@ object PrimitiveType {
   case class BigInt(validation: Validation[scala.BigInt]) extends PrimitiveType[scala.BigInt] {
     def toDynamicValue(value: scala.BigInt): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.BigInt(value))
 
-    def typeName: TypeName[scala.BigInt] = TypeName.bigInt
+    def typeId: TypeId.OfType = TypeId.bigInt
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -190,7 +194,7 @@ object PrimitiveType {
     def toDynamicValue(value: scala.BigDecimal): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.BigDecimal(value))
 
-    def typeName: TypeName[scala.BigDecimal] = TypeName.bigDecimal
+    def typeId: TypeId.OfType = TypeId.bigDecimal
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -206,7 +210,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.DayOfWeek): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.DayOfWeek(value))
 
-    def typeName: TypeName[java.time.DayOfWeek] = TypeName.dayOfWeek
+    def typeId: TypeId.OfType = TypeId.dayOfWeek
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -221,7 +225,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.Duration): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.Duration(value))
 
-    def typeName: TypeName[java.time.Duration] = TypeName.duration
+    def typeId: TypeId.OfType = TypeId.duration
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -237,7 +241,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.Instant): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.Instant(value))
 
-    def typeName: TypeName[java.time.Instant] = TypeName.instant
+    def typeId: TypeId.OfType = TypeId.instant
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -253,7 +257,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.LocalDate): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.LocalDate(value))
 
-    def typeName: TypeName[java.time.LocalDate] = TypeName.localDate
+    def typeId: TypeId.OfType = TypeId.localDate
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -269,7 +273,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.LocalDateTime): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.LocalDateTime(value))
 
-    def typeName: TypeName[java.time.LocalDateTime] = TypeName.localDateTime
+    def typeId: TypeId.OfType = TypeId.localDateTime
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -285,7 +289,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.LocalTime): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.LocalTime(value))
 
-    def typeName: TypeName[java.time.LocalTime] = TypeName.localTime
+    def typeId: TypeId.OfType = TypeId.localTime
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -300,7 +304,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.Month): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.Month(value))
 
-    def typeName: TypeName[java.time.Month] = TypeName.month
+    def typeId: TypeId.OfType = TypeId.month
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -316,7 +320,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.MonthDay): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.MonthDay(value))
 
-    def typeName: TypeName[java.time.MonthDay] = TypeName.monthDay
+    def typeId: TypeId.OfType = TypeId.monthDay
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -333,7 +337,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.OffsetDateTime): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.OffsetDateTime(value))
 
-    def typeName: TypeName[java.time.OffsetDateTime] = TypeName.offsetDateTime
+    def typeId: TypeId.OfType = TypeId.offsetDateTime
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -349,7 +353,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.OffsetTime): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.OffsetTime(value))
 
-    def typeName: TypeName[java.time.OffsetTime] = TypeName.offsetTime
+    def typeId: TypeId.OfType = TypeId.offsetTime
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -364,7 +368,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.Period): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.Period(value))
 
-    def typeName: TypeName[java.time.Period] = TypeName.period
+    def typeId: TypeId.OfType = TypeId.period
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -379,7 +383,7 @@ object PrimitiveType {
   case class Year(validation: Validation[java.time.Year]) extends PrimitiveType[java.time.Year] {
     def toDynamicValue(value: java.time.Year): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Year(value))
 
-    def typeName: TypeName[java.time.Year] = TypeName.year
+    def typeId: TypeId.OfType = TypeId.year
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -395,7 +399,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.YearMonth): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.YearMonth(value))
 
-    def typeName: TypeName[java.time.YearMonth] = TypeName.yearMonth
+    def typeId: TypeId.OfType = TypeId.yearMonth
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -410,7 +414,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.ZoneId): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.ZoneId(value))
 
-    def typeName: TypeName[java.time.ZoneId] = TypeName.zoneId
+    def typeId: TypeId.OfType = TypeId.zoneId
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -426,7 +430,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.ZoneOffset): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.ZoneOffset(value))
 
-    def typeName: TypeName[java.time.ZoneOffset] = TypeName.zoneOffset
+    def typeId: TypeId.OfType = TypeId.zoneOffset
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -442,7 +446,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.time.ZonedDateTime): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.ZonedDateTime(value))
 
-    def typeName: TypeName[java.time.ZonedDateTime] = TypeName.zonedDateTime
+    def typeId: TypeId.OfType = TypeId.zonedDateTime
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -458,7 +462,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.util.UUID): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.UUID(value))
 
-    def typeName: TypeName[java.util.UUID] = TypeName.uuid
+    def typeId: TypeId.OfType = TypeId.uuid
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -474,7 +478,7 @@ object PrimitiveType {
     def toDynamicValue(value: java.util.Currency): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.Currency(value))
 
-    def typeName: TypeName[java.util.Currency] = TypeName.currency
+    def typeId: TypeId.OfType = TypeId.currency
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,

--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -141,9 +141,16 @@ sealed trait Reflect[F[_, _], A] extends Reflectable[A] { self =>
 
   def transform[G[_, _]](path: DynamicOptic, f: ReflectTransformer[F, G]): Lazy[Reflect[G, A]]
 
-  def typeName: TypeName[A]
+  def typeId: TypeId.OfType
 
-  def typeName(value: TypeName[A]): Reflect[F, A]
+  def typeId(value: TypeId.OfType): Reflect[F, A]
+
+  // Backwards-compatible TypeName API (derived from TypeId).
+  final def typeName: TypeName[A] =
+    TypeName.fromTypeId[A](typeId)
+
+  final def typeName(value: TypeName[A]): Reflect[F, A] =
+    typeId(TypeName.toTypeId(value))
 
   def updated[B](optic: Optic[A, B])(f: Reflect[F, B] => Reflect[F, B]): Option[Reflect[F, A]] =
     updated(optic.toDynamic)(new Reflect.Updater[F] {
@@ -274,7 +281,7 @@ object Reflect {
 
   case class Record[F[_, _], A](
     fields: IndexedSeq[Term[F, A, ?]],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     recordBinding: F[BindingType.Record, A],
     doc: Doc = Doc.Empty,
     modifiers: Seq[Modifier.Reflect] = Nil
@@ -289,7 +296,7 @@ object Reflect {
       }
     }
 
-    protected def inner: Any = (fields, typeName, doc, modifiers)
+    protected def inner: Any = (fields, typeId, doc, modifiers)
 
     type NodeBinding = BindingType.Record
 
@@ -408,7 +415,7 @@ object Reflect {
     def transform[G[_, _]](path: DynamicOptic, f: ReflectTransformer[F, G]): Lazy[Record[G, A]] =
       for {
         fields <- Lazy.foreach(fields)(_.transform(path, Term.Type.Record, f))
-        record <- f.transformRecord(path, fields, typeName, recordBinding, doc, modifiers)
+        record <- f.transformRecord(path, fields, typeId, recordBinding, doc, modifiers)
       } yield record
 
     lazy val registers: IndexedSeq[Register[Any]] = ArraySeq.unsafeWrapArray(Record.registers(fieldValues))
@@ -417,7 +424,7 @@ object Reflect {
       registers.asInstanceOf[ArraySeq[Register[Any]]].unsafeArray.asInstanceOf[Array[Register[Any]]]
     )
 
-    def typeName(value: TypeName[A]): Record[F, A] = copy(typeName = value)
+    def typeId(value: TypeId.OfType): Record[F, A] = copy(typeId = value)
 
     def nodeType: Reflect.Type.Record.type = Reflect.Type.Record
 
@@ -428,6 +435,16 @@ object Reflect {
 
   object Record {
     type Bound[A] = Record[Binding, A]
+
+    // Backwards-compatible constructor taking TypeName.
+    def apply[F[_, _], A](
+      fields: IndexedSeq[Term[F, A, ?]],
+      typeName: TypeName[A],
+      recordBinding: F[BindingType.Record, A],
+      doc: Doc,
+      modifiers: Seq[Modifier.Reflect]
+    ): Record[F, A] =
+      new Record(fields, TypeName.toTypeId(typeName), recordBinding, doc, modifiers)
 
     def registers[F[_, _]](reflects: Array[Reflect[F, ?]]): Array[Register[Any]] = {
       val registers   = new Array[Register[?]](reflects.length)
@@ -487,7 +504,7 @@ object Reflect {
 
   case class Variant[F[_, _], A](
     cases: IndexedSeq[Term[F, A, ? <: A]],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     variantBinding: F[BindingType.Variant, A],
     doc: Doc = Doc.Empty,
     modifiers: Seq[Modifier.Reflect] = Nil
@@ -501,7 +518,7 @@ object Reflect {
       }
     }
 
-    protected def inner: Any = (cases, typeName, doc, modifiers)
+    protected def inner: Any = (cases, typeId, doc, modifiers)
 
     type NodeBinding = BindingType.Variant
 
@@ -577,10 +594,10 @@ object Reflect {
     def transform[G[_, _]](path: DynamicOptic, f: ReflectTransformer[F, G]): Lazy[Variant[G, A]] =
       for {
         cases   <- Lazy.foreach(cases)(_.transform(path, Term.Type.Variant, f))
-        variant <- f.transformVariant(path, cases, typeName, variantBinding, doc, modifiers)
+        variant <- f.transformVariant(path, cases, typeId, variantBinding, doc, modifiers)
       } yield variant
 
-    def typeName(value: TypeName[A]): Variant[F, A] = copy(typeName = value)
+    def typeId(value: TypeId.OfType): Variant[F, A] = copy(typeId = value)
 
     def nodeType: Reflect.Type.Variant.type = Reflect.Type.Variant
 
@@ -591,18 +608,28 @@ object Reflect {
 
   object Variant {
     type Bound[A] = Variant[Binding, A]
+
+    // Backwards-compatible constructor taking TypeName.
+    def apply[F[_, _], A](
+      cases: IndexedSeq[Term[F, A, ? <: A]],
+      typeName: TypeName[A],
+      variantBinding: F[BindingType.Variant, A],
+      doc: Doc,
+      modifiers: Seq[Modifier.Reflect]
+    ): Variant[F, A] =
+      new Variant(cases, TypeName.toTypeId(typeName), variantBinding, doc, modifiers)
   }
 
   case class Sequence[F[_, _], A, C[_]](
     element: Reflect[F, A],
-    typeName: TypeName[C[A]],
+    typeId: TypeId.OfType,
     seqBinding: F[BindingType.Seq[C], C[A]],
     doc: Doc = Doc.Empty,
     modifiers: Seq[Modifier.Reflect] = Nil
   ) extends Reflect[F, C[A]] { self =>
     require(element ne null)
 
-    protected def inner: Any = (element, typeName, doc, modifiers)
+    protected def inner: Any = (element, typeId, doc, modifiers)
 
     type NodeBinding = BindingType.Seq[C]
 
@@ -768,14 +795,14 @@ object Reflect {
     def transform[G[_, _]](path: DynamicOptic, f: ReflectTransformer[F, G]): Lazy[Sequence[G, A, C]] =
       for {
         element  <- element.transform(path(DynamicOptic.elements), f)
-        sequence <- f.transformSequence(path, element, typeName, seqBinding, doc, modifiers)
+        sequence <- f.transformSequence(path, element, typeId, seqBinding, doc, modifiers)
       } yield sequence
 
     def seqConstructor(implicit F: HasBinding[F]): SeqConstructor[C] = F.seqConstructor(seqBinding)
 
     def seqDeconstructor(implicit F: HasBinding[F]): SeqDeconstructor[C] = F.seqDeconstructor(seqBinding)
 
-    def typeName(value: TypeName[C[A]]): Sequence[F, A, C] = copy(typeName = value)
+    def typeId(value: TypeId.OfType): Sequence[F, A, C] = copy(typeId = value)
 
     def nodeType: Reflect.Type.Sequence[C] = new Reflect.Type.Sequence
 
@@ -793,6 +820,16 @@ object Reflect {
   object Sequence {
     type Bound[A, C[_]] = Sequence[Binding, A, C]
 
+    // Backwards-compatible constructor taking TypeName.
+    def apply[F[_, _], A, C[_]](
+      element: Reflect[F, A],
+      typeName: TypeName[C[A]],
+      seqBinding: F[BindingType.Seq[C], C[A]],
+      doc: Doc,
+      modifiers: Seq[Modifier.Reflect]
+    ): Sequence[F, A, C] =
+      new Sequence(element, TypeName.toTypeId(typeName), seqBinding, doc, modifiers)
+
     trait Unknown[F[_, _]] {
       type CollectionType[_]
       type ElementType
@@ -804,14 +841,14 @@ object Reflect {
   case class Map[F[_, _], K, V, M[_, _]](
     key: Reflect[F, K],
     value: Reflect[F, V],
-    typeName: TypeName[M[K, V]],
+    typeId: TypeId.OfType,
     mapBinding: F[BindingType.Map[M], M[K, V]],
     doc: Doc = Doc.Empty,
     modifiers: Seq[Modifier.Reflect] = Nil
   ) extends Reflect[F, M[K, V]] { self =>
     require((key ne null) && (value ne null))
 
-    protected def inner: Any = (key, value, typeName, doc, modifiers)
+    protected def inner: Any = (key, value, typeId, doc, modifiers)
 
     type NodeBinding = BindingType.Map[M]
 
@@ -886,10 +923,10 @@ object Reflect {
       for {
         key   <- key.transform(path(DynamicOptic.mapKeys), f)
         value <- value.transform(path(DynamicOptic.mapValues), f)
-        map   <- f.transformMap(path, key, value, typeName, mapBinding, doc, modifiers)
+        map   <- f.transformMap(path, key, value, typeId, mapBinding, doc, modifiers)
       } yield map
 
-    def typeName(value: TypeName[M[K, V]]): Map[F, K, V, M] = copy(typeName = value)
+    def typeId(value: TypeId.OfType): Map[F, K, V, M] = copy(typeId = value)
 
     def nodeType: Reflect.Type.Map[M] = new Reflect.Type.Map
 
@@ -907,6 +944,17 @@ object Reflect {
   object Map {
     type Bound[K, V, M[_, _]] = Map[Binding, K, V, M]
 
+    // Backwards-compatible constructor taking TypeName.
+    def apply[F[_, _], K, V, M[_, _]](
+      key: Reflect[F, K],
+      value: Reflect[F, V],
+      typeName: TypeName[M[K, V]],
+      mapBinding: F[BindingType.Map[M], M[K, V]],
+      doc: Doc,
+      modifiers: Seq[Modifier.Reflect]
+    ): Map[F, K, V, M] =
+      new Map(key, value, TypeName.toTypeId(typeName), mapBinding, doc, modifiers)
+
     trait Unknown[F[_, _]] {
       type MapType[_, _]
       type KeyType
@@ -918,7 +966,7 @@ object Reflect {
 
   case class Dynamic[F[_, _]](
     dynamicBinding: F[BindingType.Dynamic, DynamicValue],
-    typeName: TypeName[DynamicValue] = TypeName.dynamicValue,
+    typeId: TypeId.OfType = TypeId.dynamicValue,
     doc: Doc = Doc.Empty,
     modifiers: Seq[Modifier.Reflect] = Nil
   ) extends Reflect[F, DynamicValue] {
@@ -955,10 +1003,10 @@ object Reflect {
 
     def transform[G[_, _]](path: DynamicOptic, f: ReflectTransformer[F, G]): Lazy[Dynamic[G]] =
       for {
-        dynamic <- f.transformDynamic(path, typeName, dynamicBinding, doc, modifiers)
+        dynamic <- f.transformDynamic(path, typeId, dynamicBinding, doc, modifiers)
       } yield dynamic
 
-    def typeName(value: TypeName[DynamicValue]): Dynamic[F] = copy(typeName = value)
+    def typeId(value: TypeId.OfType): Dynamic[F] = copy(typeId = value)
 
     def nodeType: Reflect.Type.Dynamic.type = Reflect.Type.Dynamic
 
@@ -969,16 +1017,25 @@ object Reflect {
 
   object Dynamic {
     type Bound = Dynamic[Binding]
+
+    // Backwards-compatible constructor taking TypeName.
+    def apply[F[_, _]](
+      dynamicBinding: F[BindingType.Dynamic, DynamicValue],
+      typeName: TypeName[DynamicValue],
+      doc: Doc,
+      modifiers: Seq[Modifier.Reflect]
+    ): Dynamic[F] =
+      new Dynamic(dynamicBinding, TypeName.toTypeId(typeName), doc, modifiers)
   }
 
   case class Primitive[F[_, _], A](
     primitiveType: PrimitiveType[A],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     primitiveBinding: F[BindingType.Primitive, A],
     doc: Doc = Doc.Empty,
     modifiers: Seq[Modifier.Reflect] = Nil
   ) extends Reflect[F, A] { self =>
-    protected def inner: Any = (primitiveType, typeName, doc, modifiers)
+    protected def inner: Any = (primitiveType, typeId, doc, modifiers)
 
     type NodeBinding = BindingType.Primitive
 
@@ -1011,10 +1068,10 @@ object Reflect {
 
     def transform[G[_, _]](path: DynamicOptic, f: ReflectTransformer[F, G]): Lazy[Primitive[G, A]] =
       for {
-        primitive <- f.transformPrimitive(path, primitiveType, typeName, primitiveBinding, doc, modifiers)
+        primitive <- f.transformPrimitive(path, primitiveType, typeId, primitiveBinding, doc, modifiers)
       } yield primitive
 
-    def typeName(value: TypeName[A]): Primitive[F, A] = copy(typeName = value)
+    def typeId(value: TypeId.OfType): Primitive[F, A] = copy(typeId = value)
 
     def nodeType: Reflect.Type.Primitive.type = Reflect.Type.Primitive
 
@@ -1025,17 +1082,27 @@ object Reflect {
 
   object Primitive {
     type Bound[A] = Primitive[Binding, A]
+
+    // Backwards-compatible constructor taking TypeName.
+    def apply[F[_, _], A](
+      primitiveType: PrimitiveType[A],
+      typeName: TypeName[A],
+      primitiveBinding: F[BindingType.Primitive, A],
+      doc: Doc,
+      modifiers: Seq[Modifier.Reflect]
+    ): Primitive[F, A] =
+      new Primitive(primitiveType, TypeName.toTypeId(typeName), primitiveBinding, doc, modifiers)
   }
 
   case class Wrapper[F[_, _], A, B](
     wrapped: Reflect[F, B],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     wrapperPrimitiveType: Option[PrimitiveType[A]],
     wrapperBinding: F[BindingType.Wrapper[A, B], A],
     doc: Doc = Doc.Empty,
     modifiers: Seq[Modifier.Reflect] = Nil
   ) extends Reflect[F, A] { self =>
-    protected def inner: Any = (wrapped, typeName, wrapperPrimitiveType, doc, modifiers)
+    protected def inner: Any = (wrapped, typeId, wrapperPrimitiveType, doc, modifiers)
 
     type NodeBinding = BindingType.Wrapper[A, B]
 
@@ -1059,7 +1126,7 @@ object Reflect {
       (wrapped.fromDynamicValue(value) match {
         case Right(unwrapped) =>
           binding.wrap(unwrapped) match {
-            case Left(error) => new Left(SchemaError.expectationMismatch(trace, s"Expected ${typeName.name}: $error"))
+            case Left(error) => new Left(SchemaError.expectationMismatch(trace, s"Expected ${typeId.name}: $error"))
             case right       => right
           }
         case left => left
@@ -1078,10 +1145,10 @@ object Reflect {
     def transform[G[_, _]](path: DynamicOptic, f: ReflectTransformer[F, G]): Lazy[Wrapper[G, A, B]] =
       for {
         wrapped <- wrapped.transform(path, f)
-        wrapper <- f.transformWrapper(path, wrapped, typeName, wrapperPrimitiveType, wrapperBinding, doc, modifiers)
+        wrapper <- f.transformWrapper(path, wrapped, typeId, wrapperPrimitiveType, wrapperBinding, doc, modifiers)
       } yield wrapper
 
-    def typeName(value: TypeName[A]): Wrapper[F, A, B] = copy(typeName = value)
+    def typeId(value: TypeId.OfType): Wrapper[F, A, B] = copy(typeId = value)
 
     override def asWrapperUnknown: Option[Reflect.Wrapper.Unknown[F]] = new Some(new Reflect.Wrapper.Unknown[F] {
       def wrapper: Reflect.Wrapper[F, Wrapping, Wrapped] = self.asInstanceOf[Reflect.Wrapper[F, Wrapping, Wrapped]]
@@ -1094,6 +1161,17 @@ object Reflect {
 
   object Wrapper {
     type Bound[A, B] = Wrapper[Binding, A, B]
+
+    // Backwards-compatible constructor taking TypeName.
+    def apply[F[_, _], A, B](
+      wrapped: Reflect[F, B],
+      typeName: TypeName[A],
+      wrapperPrimitiveType: Option[PrimitiveType[A]],
+      wrapperBinding: F[BindingType.Wrapper[A, B], A],
+      doc: Doc,
+      modifiers: Seq[Modifier.Reflect]
+    ): Wrapper[F, A, B] =
+      new Wrapper(wrapped, TypeName.toTypeId(typeName), wrapperPrimitiveType, wrapperBinding, doc, modifiers)
 
     trait Unknown[F[_, _]] {
       type Wrapping
@@ -1154,7 +1232,7 @@ object Reflect {
         }
       }
 
-    def typeName(value: TypeName[A]): Deferred[F, A] = copy(_value = () => _value().typeName(value))
+    def typeId(value: TypeId.OfType): Deferred[F, A] = copy(_value = () => _value().typeId(value))
 
     override def hashCode: Int = {
       val v = visited.get
@@ -1340,12 +1418,12 @@ object Reflect {
       }
     }
 
-    def typeName: TypeName[A] = {
+    def typeId: TypeId.OfType = {
       val v = visited.get
       if (v.containsKey(this)) null // exit from recursion
       else {
         v.put(this, ())
-        try value.typeName
+        try value.typeId
         finally v.remove(this)
       }
     }
@@ -1442,7 +1520,7 @@ object Reflect {
     primitive(new PrimitiveType.Period(Validation.None))
 
   private[this] def primitive[F[_, _], A](primitiveType: PrimitiveType[A])(implicit F: FromBinding[F]): Reflect[F, A] =
-    new Primitive(primitiveType, primitiveType.typeName, F.fromBinding(primitiveType.binding))
+    new Primitive(primitiveType, primitiveType.typeId, F.fromBinding(primitiveType.binding))
 
   def year[F[_, _]](implicit F: FromBinding[F]): Reflect[F, java.time.Year] =
     primitive(new PrimitiveType.Year(Validation.None))
@@ -1468,49 +1546,49 @@ object Reflect {
   def dynamic[F[_, _]](implicit F: FromBinding[F]): Dynamic[F] = new Dynamic(F.fromBinding(Binding.Dynamic()))
 
   private[this] def some[F[_, _], A <: AnyRef](element: Reflect[F, A])(implicit F: FromBinding[F]): Record[F, Some[A]] =
-    new Record(Vector(new Term("value", element)), TypeName.some(element.typeName), F.fromBinding(Binding.Record.some))
+    new Record(Vector(new Term("value", element)), TypeId.some(element.typeId), F.fromBinding(Binding.Record.some))
 
   private[this] def someDouble[F[_, _]](
     element: Reflect[F, Double]
   )(implicit F: FromBinding[F]): Record[F, Some[Double]] =
     new Record(
       Vector(new Term("value", element)),
-      TypeName.some(element.typeName),
+      TypeId.some(element.typeId),
       F.fromBinding(Binding.Record.someDouble)
     )
 
   private[this] def someLong[F[_, _]](element: Reflect[F, Long])(implicit F: FromBinding[F]): Record[F, Some[Long]] =
     new Record(
       Vector(new Term("value", element)),
-      TypeName.some(element.typeName),
+      TypeId.some(element.typeId),
       F.fromBinding(Binding.Record.someLong)
     )
 
   private[this] def someFloat[F[_, _]](element: Reflect[F, Float])(implicit F: FromBinding[F]): Record[F, Some[Float]] =
     new Record(
       Vector(new Term("value", element)),
-      TypeName.some(element.typeName),
+      TypeId.some(element.typeId),
       F.fromBinding(Binding.Record.someFloat)
     )
 
   private[this] def someInt[F[_, _]](element: Reflect[F, Int])(implicit F: FromBinding[F]): Record[F, Some[Int]] =
     new Record(
       Vector(new Term("value", element)),
-      TypeName.some(element.typeName),
+      TypeId.some(element.typeId),
       F.fromBinding(Binding.Record.someInt)
     )
 
   private[this] def someChar[F[_, _]](element: Reflect[F, Char])(implicit F: FromBinding[F]): Record[F, Some[Char]] =
     new Record(
       Vector(new Term("value", element)),
-      TypeName.some(element.typeName),
+      TypeId.some(element.typeId),
       F.fromBinding(Binding.Record.someChar)
     )
 
   private[this] def someShort[F[_, _]](element: Reflect[F, Short])(implicit F: FromBinding[F]): Record[F, Some[Short]] =
     new Record(
       Vector(new Term("value", element)),
-      TypeName.some(element.typeName),
+      TypeId.some(element.typeId),
       F.fromBinding(Binding.Record.someShort)
     )
 
@@ -1519,127 +1597,127 @@ object Reflect {
   )(implicit F: FromBinding[F]): Record[F, Some[Boolean]] =
     new Record(
       Vector(new Term("value", element)),
-      TypeName.some(element.typeName),
+      TypeId.some(element.typeId),
       F.fromBinding(Binding.Record.someBoolean)
     )
 
   private[this] def someByte[F[_, _]](element: Reflect[F, Byte])(implicit F: FromBinding[F]): Record[F, Some[Byte]] =
     new Record(
       Vector(new Term("value", element)),
-      TypeName.some(element.typeName),
+      TypeId.some(element.typeId),
       F.fromBinding(Binding.Record.someByte)
     )
 
   private[this] def someUnit[F[_, _]](element: Reflect[F, Unit])(implicit F: FromBinding[F]): Record[F, Some[Unit]] =
     new Record(
       Vector(new Term("value", element)),
-      TypeName.some(element.typeName),
+      TypeId.some(element.typeId),
       F.fromBinding(Binding.Record.someUnit)
     )
 
   private[this] def none[F[_, _]](implicit F: FromBinding[F]): Record[F, None.type] =
-    new Record(Vector(), TypeName.none, F.fromBinding(Binding.Record.none))
+    new Record(Vector(), TypeId.none, F.fromBinding(Binding.Record.none))
 
   def option[F[_, _], A <: AnyRef](element: Reflect[F, A])(implicit F: FromBinding[F]): Variant[F, Option[A]] =
     new Variant(
       Vector(new Term("None", none), new Term("Some", some(element))),
-      TypeName.option(element.typeName),
+      TypeId.option(element.typeId),
       F.fromBinding(Binding.Variant.option)
     )
 
   def optionDouble[F[_, _]](element: Reflect[F, Double])(implicit F: FromBinding[F]): Variant[F, Option[Double]] =
     new Variant(
       Vector(new Term("None", none), new Term("Some", someDouble(element))),
-      TypeName.option(element.typeName),
+      TypeId.option(element.typeId),
       F.fromBinding(Binding.Variant.option)
     )
 
   def optionLong[F[_, _]](element: Reflect[F, Long])(implicit F: FromBinding[F]): Variant[F, Option[Long]] =
     new Variant(
       Vector(new Term("None", none), new Term("Some", someLong(element))),
-      TypeName.option(element.typeName),
+      TypeId.option(element.typeId),
       F.fromBinding(Binding.Variant.option)
     )
 
   def optionFloat[F[_, _]](element: Reflect[F, Float])(implicit F: FromBinding[F]): Variant[F, Option[Float]] =
     new Variant(
       Vector(new Term("None", none), new Term("Some", someFloat(element))),
-      TypeName.option(element.typeName),
+      TypeId.option(element.typeId),
       F.fromBinding(Binding.Variant.option)
     )
 
   def optionInt[F[_, _]](element: Reflect[F, Int])(implicit F: FromBinding[F]): Variant[F, Option[Int]] =
     new Variant(
       Vector(new Term("None", none), new Term("Some", someInt(element))),
-      TypeName.option(element.typeName),
+      TypeId.option(element.typeId),
       F.fromBinding(Binding.Variant.option)
     )
 
   def optionChar[F[_, _]](element: Reflect[F, Char])(implicit F: FromBinding[F]): Variant[F, Option[Char]] =
     new Variant(
       Vector(new Term("None", none), new Term("Some", someChar(element))),
-      TypeName.option(element.typeName),
+      TypeId.option(element.typeId),
       F.fromBinding(Binding.Variant.option)
     )
 
   def optionShort[F[_, _]](element: Reflect[F, Short])(implicit F: FromBinding[F]): Variant[F, Option[Short]] =
     new Variant(
       Vector(new Term("None", none), new Term("Some", someShort(element))),
-      TypeName.option(element.typeName),
+      TypeId.option(element.typeId),
       F.fromBinding(Binding.Variant.option)
     )
 
   def optionBoolean[F[_, _]](element: Reflect[F, Boolean])(implicit F: FromBinding[F]): Variant[F, Option[Boolean]] =
     new Variant(
       Vector(new Term("None", none), new Term("Some", someBoolean(element))),
-      TypeName.option(element.typeName),
+      TypeId.option(element.typeId),
       F.fromBinding(Binding.Variant.option)
     )
 
   def optionByte[F[_, _]](element: Reflect[F, Byte])(implicit F: FromBinding[F]): Variant[F, Option[Byte]] =
     new Variant(
       Vector(new Term("None", none), new Term("Some", someByte(element))),
-      TypeName.option(element.typeName),
+      TypeId.option(element.typeId),
       F.fromBinding(Binding.Variant.option)
     )
 
   def optionUnit[F[_, _]](element: Reflect[F, Unit])(implicit F: FromBinding[F]): Variant[F, Option[Unit]] =
     new Variant(
       Vector(new Term("None", none), new Term("Some", someUnit(element))),
-      TypeName.option(element.typeName),
+      TypeId.option(element.typeId),
       F.fromBinding(Binding.Variant.option)
     )
 
   def set[F[_, _], A](element: Reflect[F, A])(implicit F: FromBinding[F]): Sequence[F, A, Set] =
-    new Sequence(element, TypeName.set(element.typeName), F.fromBinding(Binding.Seq.set))
+    new Sequence(element, TypeId.set(element.typeId), F.fromBinding(Binding.Seq.set))
 
   def list[F[_, _], A](element: Reflect[F, A])(implicit F: FromBinding[F]): Sequence[F, A, List] =
-    new Sequence(element, TypeName.list(element.typeName), F.fromBinding(Binding.Seq.list))
+    new Sequence(element, TypeId.list(element.typeId), F.fromBinding(Binding.Seq.list))
 
   def vector[F[_, _], A](element: Reflect[F, A])(implicit F: FromBinding[F]): Sequence[F, A, Vector] =
-    new Sequence(element, TypeName.vector(element.typeName), F.fromBinding(Binding.Seq.vector))
+    new Sequence(element, TypeId.vector(element.typeId), F.fromBinding(Binding.Seq.vector))
 
   def arraySeq[F[_, _], A](element: Reflect[F, A])(implicit F: FromBinding[F]): Sequence[F, A, ArraySeq] =
-    new Sequence(element, TypeName.arraySeq(element.typeName), F.fromBinding(Binding.Seq.arraySeq))
+    new Sequence(element, TypeId.arraySeq(element.typeId), F.fromBinding(Binding.Seq.arraySeq))
 
   def indexedSeq[F[_, _], A](element: Reflect[F, A])(implicit F: FromBinding[F]): Sequence[F, A, IndexedSeq] =
-    new Sequence(element, TypeName.indexedSeq(element.typeName), F.fromBinding(Binding.Seq.indexedSeq))
+    new Sequence(element, TypeId.indexedSeq(element.typeId), F.fromBinding(Binding.Seq.indexedSeq))
 
   def seq[F[_, _], A](element: Reflect[F, A])(implicit F: FromBinding[F]): Sequence[F, A, Seq] =
-    new Sequence(element, TypeName.seq(element.typeName), F.fromBinding(Binding.Seq.seq))
+    new Sequence(element, TypeId.seq(element.typeId), F.fromBinding(Binding.Seq.seq))
 
   def map[F[_, _], K, V](key: Reflect[F, K], value: Reflect[F, V])(implicit
     F: FromBinding[F]
   ): Map[F, K, V, collection.immutable.Map] = {
-    val typeName = TypeName.map(key.typeName, value.typeName)
-    new Map(key, value, typeName, F.fromBinding(Binding.Map.map))
+    val typeId = TypeId.map(key.typeId, value.typeId)
+    new Map(key, value, typeId, F.fromBinding(Binding.Map.map))
   }
 
   object Extractors {
     object List {
       def unapply[F[_, _], A](reflect: Reflect[F, List[A]]): Option[Reflect[F, A]] =
         reflect.asSequenceUnknown.collect {
-          case x if x.sequence.typeName == TypeName.list(x.sequence.element.typeName) =>
+          case x if x.sequence.typeId == TypeId.list(x.sequence.element.typeId) =>
             x.sequence.element.asInstanceOf[Reflect[F, A]]
         }
     }
@@ -1647,7 +1725,7 @@ object Reflect {
     object Vector {
       def unapply[F[_, _], A](reflect: Reflect[F, Vector[A]]): Option[Reflect[F, A]] =
         reflect.asSequenceUnknown.collect {
-          case x if x.sequence.typeName == TypeName.vector(x.sequence.element.typeName) =>
+          case x if x.sequence.typeId == TypeId.vector(x.sequence.element.typeId) =>
             x.sequence.element.asInstanceOf[Reflect[F, A]]
         }
     }
@@ -1655,7 +1733,7 @@ object Reflect {
     object Set {
       def unapply[F[_, _], A](reflect: Reflect[F, Set[A]]): Option[Reflect[F, A]] =
         reflect.asSequenceUnknown.collect {
-          case x if x.sequence.typeName == TypeName.set(x.sequence.element.typeName) =>
+          case x if x.sequence.typeId == TypeId.set(x.sequence.element.typeId) =>
             x.sequence.element.asInstanceOf[Reflect[F, A]]
         }
     }
@@ -1663,7 +1741,7 @@ object Reflect {
     object ArraySeq {
       def unapply[F[_, _], A](reflect: Reflect[F, ArraySeq[A]]): Option[Reflect[F, A]] =
         reflect.asSequenceUnknown.collect {
-          case x if x.sequence.typeName == TypeName.arraySeq(x.sequence.element.typeName) =>
+          case x if x.sequence.typeId == TypeId.arraySeq(x.sequence.element.typeId) =>
             x.sequence.element.asInstanceOf[Reflect[F, A]]
         }
     }

--- a/schema/shared/src/main/scala/zio/blocks/schema/ReflectTransformer.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/ReflectTransformer.scala
@@ -6,7 +6,7 @@ trait ReflectTransformer[-F[_, _], G[_, _]] {
   def transformRecord[A](
     path: DynamicOptic,
     fields: IndexedSeq[Term[G, A, ?]],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     metadata: F[BindingType.Record, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
@@ -15,7 +15,7 @@ trait ReflectTransformer[-F[_, _], G[_, _]] {
   def transformVariant[A](
     path: DynamicOptic,
     cases: IndexedSeq[Term[G, A, ? <: A]],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     metadata: F[BindingType.Variant, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
@@ -24,7 +24,7 @@ trait ReflectTransformer[-F[_, _], G[_, _]] {
   def transformSequence[A, C[_]](
     path: DynamicOptic,
     element: Reflect[G, A],
-    typeName: TypeName[C[A]],
+    typeId: TypeId.OfType,
     metadata: F[BindingType.Seq[C], C[A]],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
@@ -34,7 +34,7 @@ trait ReflectTransformer[-F[_, _], G[_, _]] {
     path: DynamicOptic,
     key: Reflect[G, Key],
     value: Reflect[G, Value],
-    typeName: TypeName[M[Key, Value]],
+    typeId: TypeId.OfType,
     metadata: F[BindingType.Map[M], M[Key, Value]],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
@@ -42,7 +42,7 @@ trait ReflectTransformer[-F[_, _], G[_, _]] {
 
   def transformDynamic(
     path: DynamicOptic,
-    typeName: TypeName[DynamicValue],
+    typeId: TypeId.OfType,
     metadata: F[BindingType.Dynamic, DynamicValue],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
@@ -51,7 +51,7 @@ trait ReflectTransformer[-F[_, _], G[_, _]] {
   def transformPrimitive[A](
     path: DynamicOptic,
     primitiveType: PrimitiveType[A],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     metadata: F[BindingType.Primitive, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
@@ -60,7 +60,7 @@ trait ReflectTransformer[-F[_, _], G[_, _]] {
   def transformWrapper[A, B](
     path: DynamicOptic,
     wrapped: Reflect[G, B],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     wrapperPrimitiveType: Option[PrimitiveType[A]],
     metadata: F[BindingType.Wrapper[A, B], A],
     doc: Doc,
@@ -75,79 +75,79 @@ object ReflectTransformer {
     def transformRecord[A](
       path: DynamicOptic,
       fields: IndexedSeq[Term[G, A, ?]],
-      typeName: TypeName[A],
+      typeId: TypeId.OfType,
       metadata: F[BindingType.Record, A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect]
     ): Lazy[Reflect.Record[G, A]] =
       for {
         binding <- transformMetadata(metadata)
-      } yield new Reflect.Record(fields, typeName, binding, doc, modifiers)
+      } yield new Reflect.Record(fields, typeId, binding, doc, modifiers)
 
     def transformVariant[A](
       path: DynamicOptic,
       cases: IndexedSeq[Term[G, A, ? <: A]],
-      typeName: TypeName[A],
+      typeId: TypeId.OfType,
       metadata: F[BindingType.Variant, A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect]
     ): Lazy[Reflect.Variant[G, A]] =
       for {
         binding <- transformMetadata(metadata)
-      } yield new Reflect.Variant(cases, typeName, binding, doc, modifiers)
+      } yield new Reflect.Variant(cases, typeId, binding, doc, modifiers)
 
     def transformSequence[A, C[_]](
       path: DynamicOptic,
       element: Reflect[G, A],
-      typeName: TypeName[C[A]],
+      typeId: TypeId.OfType,
       metadata: F[BindingType.Seq[C], C[A]],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect]
     ): Lazy[Reflect.Sequence[G, A, C]] =
       for {
         binding <- transformMetadata(metadata)
-      } yield new Reflect.Sequence(element, typeName, binding, doc, modifiers)
+      } yield new Reflect.Sequence(element, typeId, binding, doc, modifiers)
 
     def transformMap[Key, Value, M[_, _]](
       path: DynamicOptic,
       key: Reflect[G, Key],
       value: Reflect[G, Value],
-      typeName: TypeName[M[Key, Value]],
+      typeId: TypeId.OfType,
       metadata: F[BindingType.Map[M], M[Key, Value]],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect]
     ): Lazy[Reflect.Map[G, Key, Value, M]] =
       for {
         binding <- transformMetadata(metadata)
-      } yield Reflect.Map(key, value, typeName, binding, doc, modifiers)
+      } yield Reflect.Map(key, value, typeId, binding, doc, modifiers)
 
     def transformDynamic(
       path: DynamicOptic,
-      typeName: TypeName[DynamicValue],
+      typeId: TypeId.OfType,
       metadata: F[BindingType.Dynamic, DynamicValue],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect]
     ): Lazy[Reflect.Dynamic[G]] =
       for {
         binding <- transformMetadata(metadata)
-      } yield new Reflect.Dynamic(binding, typeName, doc, modifiers)
+      } yield new Reflect.Dynamic(binding, typeId, doc, modifiers)
 
     def transformPrimitive[A](
       path: DynamicOptic,
       primitiveType: PrimitiveType[A],
-      typeName: TypeName[A],
+      typeId: TypeId.OfType,
       metadata: F[BindingType.Primitive, A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect]
     ): Lazy[Reflect.Primitive[G, A]] =
       for {
         binding <- transformMetadata(metadata)
-      } yield new Reflect.Primitive(primitiveType, typeName, binding, doc, modifiers)
+      } yield new Reflect.Primitive(primitiveType, typeId, binding, doc, modifiers)
 
     def transformWrapper[A, B](
       path: DynamicOptic,
       wrapped: Reflect[G, B],
-      typeName: TypeName[A],
+      typeId: TypeId.OfType,
       wrapperPrimitiveType: Option[PrimitiveType[A]],
       metadata: F[BindingType.Wrapper[A, B], A],
       doc: Doc,
@@ -155,7 +155,7 @@ object ReflectTransformer {
     ): Lazy[Reflect.Wrapper[G, A, B]] =
       for {
         binding <- transformMetadata(metadata)
-      } yield new Reflect.Wrapper(wrapped, typeName, wrapperPrimitiveType, binding, doc, modifiers)
+      } yield new Reflect.Wrapper(wrapped, typeId, wrapperPrimitiveType, binding, doc, modifiers)
   }
 
   private type Any2[_, _] = Any

--- a/schema/shared/src/main/scala/zio/blocks/schema/Schema.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Schema.scala
@@ -80,7 +80,7 @@ final case class Schema[A](reflect: Reflect.Bound[A]) {
   def wrap[B: Schema](wrap: B => Either[String, A], unwrap: A => B): Schema[A] = new Schema(
     new Reflect.Wrapper[Binding, A, B](
       Schema[B].reflect,
-      reflect.typeName,
+      reflect.typeId,
       Reflect.unwrapToPrimitiveTypeOption(reflect),
       new Binding.Wrapper(wrap, unwrap)
     )
@@ -89,7 +89,7 @@ final case class Schema[A](reflect: Reflect.Bound[A]) {
   def wrapTotal[B: Schema](wrap: B => A, unwrap: A => B): Schema[A] = new Schema(
     new Reflect.Wrapper[Binding, A, B](
       Schema[B].reflect,
-      reflect.typeName,
+      reflect.typeId,
       Reflect.unwrapToPrimitiveTypeOption(reflect),
       new Binding.Wrapper(x => new Right(wrap(x)), unwrap)
     )

--- a/schema/shared/src/main/scala/zio/blocks/schema/TypeId.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/TypeId.scala
@@ -1,0 +1,108 @@
+package zio.blocks.schema
+
+/**
+ * Phantom-tagged type identifiers.
+ *
+ * At runtime, a TypeId is always just a `TypeIdRepr`.
+ */
+object TypeId extends TypeIdVersionSpecific {
+  trait Tagged[+U] extends Any
+  type @@[+T, +U] = T with Tagged[U]
+
+  // Type-level naturals for arity.
+  sealed trait Nat
+  sealed trait _0 extends Nat
+  sealed trait Succ[N <: Nat] extends Nat
+
+  type _1 = Succ[_0]
+  type _2 = Succ[_1]
+  type _3 = Succ[_2]
+  type _4 = Succ[_3]
+  type _5 = Succ[_4]
+
+  sealed trait KindTag { type Arity <: Nat }
+  object KindTag {
+    sealed trait Type extends KindTag { type Arity = _0 }
+    sealed trait Constructor[N <: Nat] extends KindTag { type Arity = N }
+  }
+
+  type Id[+K <: KindTag] = TypeIdRepr @@ K
+  type OfType            = Id[KindTag.Type]
+
+  private[schema] def unsafeTag[K <: KindTag](repr: TypeIdRepr): Id[K] =
+    repr.asInstanceOf[Id[K]]
+
+  private[this] def ofType(repr: TypeIdRepr): OfType =
+    unsafeTag[KindTag.Type](repr)
+
+  // ---- Common type ids (kind = *) ----
+  val unit: OfType = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "Unit", Nil))
+
+  val boolean: OfType = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "Boolean", Nil))
+  val byte: OfType    = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "Byte", Nil))
+  val short: OfType   = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "Short", Nil))
+  val int: OfType     = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "Int", Nil))
+  val long: OfType    = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "Long", Nil))
+  val float: OfType   = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "Float", Nil))
+  val double: OfType  = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "Double", Nil))
+  val char: OfType    = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "Char", Nil))
+
+  val string: OfType     = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "String", Nil))
+  val bigInt: OfType     = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "BigInt", Nil))
+  val bigDecimal: OfType = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "BigDecimal", Nil))
+
+  val dayOfWeek: OfType  = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "DayOfWeek", Nil))
+  val duration: OfType   = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "Duration", Nil))
+  val instant: OfType    = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "Instant", Nil))
+  val localDate: OfType  = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "LocalDate", Nil))
+  val localDateTime: OfType =
+    ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "LocalDateTime", Nil))
+  val localTime: OfType      = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "LocalTime", Nil))
+  val month: OfType          = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "Month", Nil))
+  val monthDay: OfType       = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "MonthDay", Nil))
+  val offsetDateTime: OfType = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "OffsetDateTime", Nil))
+  val offsetTime: OfType     = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "OffsetTime", Nil))
+  val period: OfType         = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "Period", Nil))
+  val year: OfType           = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "Year", Nil))
+  val yearMonth: OfType      = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "YearMonth", Nil))
+  val zoneId: OfType         = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "ZoneId", Nil))
+  val zoneOffset: OfType     = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "ZoneOffset", Nil))
+  val zonedDateTime: OfType  = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "ZonedDateTime", Nil))
+
+  val currency: OfType = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaUtil), "Currency", Nil))
+  val uuid: OfType     = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaUtil), "UUID", Nil))
+
+  val none: OfType         = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "None", Nil))
+  val dynamicValue: OfType = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.zioBlocksSchema), "DynamicValue", Nil))
+
+  // Collections / constructors with applied params
+  def some(element: OfType): OfType = ofType(_some.copy(params = new TypeParam(element) :: Nil))
+
+  def option(element: OfType): OfType = ofType(_option.copy(params = new TypeParam(element) :: Nil))
+
+  def list(element: OfType): OfType = ofType(_list.copy(params = new TypeParam(element) :: Nil))
+
+  def map(key: OfType, value: OfType): OfType =
+    ofType(_map.copy(params = new TypeParam(key) :: new TypeParam(value) :: Nil))
+
+  def set(element: OfType): OfType = ofType(_set.copy(params = new TypeParam(element) :: Nil))
+
+  def vector(element: OfType): OfType = ofType(_vector.copy(params = new TypeParam(element) :: Nil))
+
+  def arraySeq(element: OfType): OfType = ofType(_arraySeq.copy(params = new TypeParam(element) :: Nil))
+
+  def indexedSeq(element: OfType): OfType = ofType(_indexedSeq.copy(params = new TypeParam(element) :: Nil))
+
+  def seq(element: OfType): OfType = ofType(_seq.copy(params = new TypeParam(element) :: Nil))
+
+  private[this] val _some       = new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "Some", Nil)
+  private[this] val _option     = new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "Option", Nil)
+  private[this] val _list       = new TypeIdRepr(Owner.fromNamespace(Namespace.scalaCollectionImmutable), "List", Nil)
+  private[this] val _map        = new TypeIdRepr(Owner.fromNamespace(Namespace.scalaCollectionImmutable), "Map", Nil)
+  private[this] val _set        = new TypeIdRepr(Owner.fromNamespace(Namespace.scalaCollectionImmutable), "Set", Nil)
+  private[this] val _vector     = new TypeIdRepr(Owner.fromNamespace(Namespace.scalaCollectionImmutable), "Vector", Nil)
+  private[this] val _arraySeq   = new TypeIdRepr(Owner.fromNamespace(Namespace.scalaCollectionImmutable), "ArraySeq", Nil)
+  private[this] val _indexedSeq = new TypeIdRepr(Owner.fromNamespace(Namespace.scalaCollectionImmutable), "IndexedSeq", Nil)
+  private[this] val _seq        = new TypeIdRepr(Owner.fromNamespace(Namespace.scalaCollectionImmutable), "Seq", Nil)
+}
+

--- a/schema/shared/src/main/scala/zio/blocks/schema/TypeId.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/TypeId.scala
@@ -11,7 +11,7 @@ object TypeId extends TypeIdVersionSpecific {
 
   // Type-level naturals for arity.
   sealed trait Nat
-  sealed trait _0 extends Nat
+  sealed trait _0             extends Nat
   sealed trait Succ[N <: Nat] extends Nat
 
   type _1 = Succ[_0]
@@ -21,9 +21,9 @@ object TypeId extends TypeIdVersionSpecific {
   type _5 = Succ[_4]
 
   sealed trait KindTag { type Arity <: Nat }
-  object KindTag {
-    sealed trait Type extends KindTag { type Arity = _0 }
-    sealed trait Constructor[N <: Nat] extends KindTag { type Arity = N }
+  object KindTag       {
+    sealed trait Type                  extends KindTag { type Arity = _0 }
+    sealed trait Constructor[N <: Nat] extends KindTag { type Arity = N  }
   }
 
   type Id[+K <: KindTag] = TypeIdRepr @@ K
@@ -51,10 +51,10 @@ object TypeId extends TypeIdVersionSpecific {
   val bigInt: OfType     = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "BigInt", Nil))
   val bigDecimal: OfType = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "BigDecimal", Nil))
 
-  val dayOfWeek: OfType  = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "DayOfWeek", Nil))
-  val duration: OfType   = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "Duration", Nil))
-  val instant: OfType    = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "Instant", Nil))
-  val localDate: OfType  = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "LocalDate", Nil))
+  val dayOfWeek: OfType     = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "DayOfWeek", Nil))
+  val duration: OfType      = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "Duration", Nil))
+  val instant: OfType       = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "Instant", Nil))
+  val localDate: OfType     = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "LocalDate", Nil))
   val localDateTime: OfType =
     ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "LocalDateTime", Nil))
   val localTime: OfType      = ofType(new TypeIdRepr(Owner.fromNamespace(Namespace.javaTime), "LocalTime", Nil))
@@ -102,7 +102,7 @@ object TypeId extends TypeIdVersionSpecific {
   private[this] val _set        = new TypeIdRepr(Owner.fromNamespace(Namespace.scalaCollectionImmutable), "Set", Nil)
   private[this] val _vector     = new TypeIdRepr(Owner.fromNamespace(Namespace.scalaCollectionImmutable), "Vector", Nil)
   private[this] val _arraySeq   = new TypeIdRepr(Owner.fromNamespace(Namespace.scalaCollectionImmutable), "ArraySeq", Nil)
-  private[this] val _indexedSeq = new TypeIdRepr(Owner.fromNamespace(Namespace.scalaCollectionImmutable), "IndexedSeq", Nil)
-  private[this] val _seq        = new TypeIdRepr(Owner.fromNamespace(Namespace.scalaCollectionImmutable), "Seq", Nil)
+  private[this] val _indexedSeq =
+    new TypeIdRepr(Owner.fromNamespace(Namespace.scalaCollectionImmutable), "IndexedSeq", Nil)
+  private[this] val _seq = new TypeIdRepr(Owner.fromNamespace(Namespace.scalaCollectionImmutable), "Seq", Nil)
 }
-

--- a/schema/shared/src/main/scala/zio/blocks/schema/TypeIdRepr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/TypeIdRepr.scala
@@ -1,0 +1,12 @@
+package zio.blocks.schema
+
+/**
+ * The single runtime representation of a type identifier.
+ *
+ * Everything else in the TypeId system is phantom typing / tagging.
+ */
+final case class TypeIdRepr(
+  owner: Owner,
+  name: String,
+  params: List[TypeParam]
+)

--- a/schema/shared/src/main/scala/zio/blocks/schema/TypeParam.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/TypeParam.scala
@@ -1,0 +1,9 @@
+package zio.blocks.schema
+
+/**
+ * A type parameter inside a TypeId.
+ *
+ * This is a wrapper ADT to keep the runtime representation extensible
+ * (aliases, opaques, structural types, etc.) without changing TypeIdRepr.
+ */
+final case class TypeParam(id: TypeIdRepr)

--- a/schema/shared/src/main/scala/zio/blocks/schema/TypeParam.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/TypeParam.scala
@@ -3,7 +3,7 @@ package zio.blocks.schema
 /**
  * A type parameter inside a TypeId.
  *
- * This is a wrapper ADT to keep the runtime representation extensible
- * (aliases, opaques, structural types, etc.) without changing TypeIdRepr.
+ * This is a wrapper ADT to keep the runtime representation extensible (aliases,
+ * opaques, structural types, etc.) without changing TypeIdRepr.
  */
 final case class TypeParam(id: TypeIdRepr)

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/DerivationBuilder.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/DerivationBuilder.scala
@@ -28,11 +28,17 @@ final case class DerivationBuilder[TC[_], A](
   def instance[B](optic: Optic[A, B], instance: => TC[B]): DerivationBuilder[TC, A] =
     copy(instanceOverrides = instanceOverrides :+ new InstanceOverrideByOptic(optic.toDynamic, Lazy(instance)))
 
-  def instance[B](typeName: TypeName[B], instance: => TC[B]): DerivationBuilder[TC, A] =
-    copy(instanceOverrides = instanceOverrides :+ new InstanceOverrideByType(typeName, Lazy(instance)))
+  def instance[B](typeId: TypeId.OfType, instance: => TC[B]): DerivationBuilder[TC, A] =
+    copy(instanceOverrides = instanceOverrides :+ new InstanceOverrideByType(typeId, Lazy(instance)))
 
-  def modifier[B](typeName: TypeName[B], modifier: Modifier.Reflect): DerivationBuilder[TC, A] =
-    copy(modifierOverrides = modifierOverrides :+ new ModifierReflectOverrideByType(typeName, modifier))
+  def instance[B](typeName: TypeName[B], inst: => TC[B]): DerivationBuilder[TC, A] =
+    this.instance(TypeName.toTypeId(typeName), inst)
+
+  def modifier[B](typeId: TypeId.OfType, modifier: Modifier.Reflect): DerivationBuilder[TC, A] =
+    copy(modifierOverrides = modifierOverrides :+ new ModifierReflectOverrideByType(typeId, modifier))
+
+  def modifier[B](typeName: TypeName[B], mod: Modifier.Reflect): DerivationBuilder[TC, A] =
+    this.modifier(TypeName.toTypeId(typeName), mod)
 
   def modifier[B](optic: Optic[A, B], modifier: Modifier): DerivationBuilder[TC, A] = modifier match {
     case mr: Modifier.Reflect =>
@@ -58,7 +64,7 @@ final case class DerivationBuilder[TC[_], A](
     val instanceByOpticMap   =
       allInstanceOverrides.collect { case InstanceOverrideByOptic(optic, instance) => (optic, instance) }.toMap
     val instanceByTypeMap =
-      allInstanceOverrides.collect { case InstanceOverrideByType(typeName, instance) => (typeName, instance) }.toMap
+      allInstanceOverrides.collect { case InstanceOverrideByType(typeId, instance) => (typeId, instance) }.toMap
     val modifierReflectByOpticMap =
       allModifierOverrides.foldLeft[Map[DynamicOptic, Vector[Modifier.Reflect]]](Map.empty) {
         case (acc, ModifierReflectOverrideByOptic(optic, modifier)) =>
@@ -66,9 +72,9 @@ final case class DerivationBuilder[TC[_], A](
         case (acc, _) => acc
       }
     val modifierReflectByTypeMap =
-      allModifierOverrides.foldLeft[Map[TypeName[?], Vector[Modifier.Reflect]]](Map.empty) {
-        case (acc, ModifierReflectOverrideByType(typeName, modifier)) =>
-          acc.updated(typeName, acc.getOrElse(typeName, Vector.empty).appended(modifier))
+      allModifierOverrides.foldLeft[Map[TypeId.OfType, Vector[Modifier.Reflect]]](Map.empty) {
+        case (acc, ModifierReflectOverrideByType(typeId, modifier)) =>
+          acc.updated(typeId, acc.getOrElse(typeId, Vector.empty).appended(modifier))
         case (acc, _) => acc
       }
     val modifierTermByOpticMap =
@@ -78,34 +84,34 @@ final case class DerivationBuilder[TC[_], A](
         case (acc, _) => acc
       }
     val modifierTermByTypeMap =
-      allModifierOverrides.foldLeft[Map[TypeName[?], Vector[(String, Modifier.Term)]]](Map.empty) {
-        case (acc, ModifierTermOverrideByType(typeName, termName, modifier)) =>
-          acc.updated(typeName, acc.getOrElse(typeName, Vector.empty).appended((termName, modifier)))
+      allModifierOverrides.foldLeft[Map[TypeId.OfType, Vector[(String, Modifier.Term)]]](Map.empty) {
+        case (acc, ModifierTermOverrideByType(typeId, termName, modifier)) =>
+          acc.updated(typeId, acc.getOrElse(typeId, Vector.empty).appended((termName, modifier)))
         case (acc, _) => acc
       }
 
-    def prependCombinedModifiers[A0](modifiers: Seq[Modifier.Reflect], path: DynamicOptic, typeName: TypeName[A0]) =
-      (modifierReflectByOpticMap.get(path), modifierReflectByTypeMap.get(typeName)) match {
+    def prependCombinedModifiers[A0](modifiers: Seq[Modifier.Reflect], path: DynamicOptic, typeId: TypeId.OfType) =
+      (modifierReflectByOpticMap.get(path), modifierReflectByTypeMap.get(typeId)) match {
         case (Some(modifiers1), Some(modifiers2)) => (modifiers1 ++ modifiers2) ++ modifiers
         case (Some(modifiers1), _)                => modifiers1 ++ modifiers
         case (_, Some(modifiers2))                => modifiers2 ++ modifiers
         case _                                    => modifiers
       }
 
-    def combineModifiers[A0](path: DynamicOptic, typeName: TypeName[A0]) =
-      (modifierTermByOpticMap.get(path), modifierTermByTypeMap.get(typeName)) match {
+    def combineModifiers[A0](path: DynamicOptic, typeId: TypeId.OfType) =
+      (modifierTermByOpticMap.get(path), modifierTermByTypeMap.get(typeId)) match {
         case (Some(modifiers1), Some(modifiers2)) => modifiers1 ++ modifiers2
         case (Some(modifiers1), _)                => modifiers1
         case (_, Some(modifiers2))                => modifiers2
         case _                                    => Seq.empty
       }
 
-    def getCustomInstance[A0](path: DynamicOptic, typeName: TypeName[A0]): Option[Lazy[TC[A0]]] =
+    def getCustomInstance[A0](path: DynamicOptic, typeId: TypeId.OfType): Option[Lazy[TC[A0]]] =
       // first try to find an instance by optic (more precise)
       instanceByOpticMap
         .get(path)
         // then try to find an instance by type name (more general)
-        .orElse(instanceByTypeMap.get(typeName.asInstanceOf[TypeName[Any]]))
+        .orElse(instanceByTypeMap.get(typeId))
         .map(_.asInstanceOf[Lazy[TC[A0]]])
 
     type F[T, A0] = Binding[T, A0]
@@ -118,13 +124,13 @@ final case class DerivationBuilder[TC[_], A](
           override def transformRecord[A0](
             path: DynamicOptic,
             fields: IndexedSeq[Term[G, A0, ?]],
-            typeName: TypeName[A0],
+            typeId: TypeId.OfType,
             metadata: F[BindingType.Record, A0],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect]
           ): Lazy[Reflect.Record[G, A0]] = Lazy {
-            val instance = getCustomInstance[A0](path, typeName).getOrElse {
-              val modifiersToPrepend = combineModifiers(path, typeName)
+            val instance = getCustomInstance[A0](path, typeId).getOrElse {
+              val modifiersToPrepend = combineModifiers(path, typeId)
               val updatedFields      =
                 if (modifiersToPrepend.isEmpty) fields
                 else {
@@ -139,25 +145,25 @@ final case class DerivationBuilder[TC[_], A](
               deriver
                 .deriveRecord(
                   updatedFields,
-                  typeName,
+                  typeId,
                   metadata,
                   doc,
-                  prependCombinedModifiers(modifiers, path, typeName)
+                  prependCombinedModifiers(modifiers, path, typeId)
                 )
             }
-            new Reflect.Record(fields, typeName, new BindingInstance(metadata, instance), doc, modifiers)
+            new Reflect.Record(fields, typeId, new BindingInstance(metadata, instance), doc, modifiers)
           }
 
           override def transformVariant[A0](
             path: DynamicOptic,
             cases: IndexedSeq[Term[G, A0, ? <: A0]],
-            typeName: TypeName[A0],
+            typeId: TypeId.OfType,
             metadata: F[BindingType.Variant, A0],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect]
           ): Lazy[Reflect.Variant[G, A0]] = Lazy {
-            val instance = getCustomInstance[A0](path, typeName).getOrElse {
-              val modifiersToAdd = combineModifiers(path, typeName)
+            val instance = getCustomInstance[A0](path, typeId).getOrElse {
+              val modifiersToAdd = combineModifiers(path, typeId)
               val updatedCases   =
                 if (modifiersToAdd.isEmpty) cases
                 else {
@@ -175,102 +181,102 @@ final case class DerivationBuilder[TC[_], A](
               deriver
                 .deriveVariant(
                   updatedCases,
-                  typeName,
+                  typeId,
                   metadata,
                   doc,
-                  prependCombinedModifiers(modifiers, path, typeName)
+                  prependCombinedModifiers(modifiers, path, typeId)
                 )
             }
-            new Reflect.Variant(cases, typeName, new BindingInstance(metadata, instance), doc, modifiers)
+            new Reflect.Variant(cases, typeId, new BindingInstance(metadata, instance), doc, modifiers)
           }
 
           override def transformSequence[A0, C[_]](
             path: DynamicOptic,
             element: Reflect[G, A0],
-            typeName: TypeName[C[A0]],
+            typeId: TypeId.OfType,
             metadata: F[BindingType.Seq[C], C[A0]],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect]
           ): Lazy[Reflect.Sequence[G, A0, C]] = Lazy {
-            val instance = getCustomInstance[C[A0]](path, typeName).getOrElse(
+            val instance = getCustomInstance[C[A0]](path, typeId).getOrElse(
               deriver
-                .deriveSequence(element, typeName, metadata, doc, prependCombinedModifiers(modifiers, path, typeName))
+                .deriveSequence(element, typeId, metadata, doc, prependCombinedModifiers(modifiers, path, typeId))
             )
-            new Reflect.Sequence(element, typeName, new BindingInstance(metadata, instance), doc, modifiers)
+            new Reflect.Sequence(element, typeId, new BindingInstance(metadata, instance), doc, modifiers)
           }
 
           override def transformMap[Key, Value, M[_, _]](
             path: DynamicOptic,
             key: Reflect[G, Key],
             value: Reflect[G, Value],
-            typeName: TypeName[M[Key, Value]],
+            typeId: TypeId.OfType,
             metadata: F[BindingType.Map[M], M[Key, Value]],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect]
           ): Lazy[Reflect.Map[G, Key, Value, M]] = Lazy {
-            val instance = getCustomInstance[M[Key, Value]](path, typeName).getOrElse(
+            val instance = getCustomInstance[M[Key, Value]](path, typeId).getOrElse(
               deriver
-                .deriveMap(key, value, typeName, metadata, doc, prependCombinedModifiers(modifiers, path, typeName))
+                .deriveMap(key, value, typeId, metadata, doc, prependCombinedModifiers(modifiers, path, typeId))
             )
-            new Reflect.Map(key, value, typeName, new BindingInstance(metadata, instance), doc, modifiers)
+            new Reflect.Map(key, value, typeId, new BindingInstance(metadata, instance), doc, modifiers)
           }
 
           override def transformDynamic(
             path: DynamicOptic,
-            typeName: TypeName[DynamicValue],
+            typeId: TypeId.OfType,
             metadata: F[BindingType.Dynamic, DynamicValue],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect]
           ): Lazy[Reflect.Dynamic[G]] = Lazy {
-            val instance = getCustomInstance[DynamicValue](path, TypeName.dynamicValue)
-              .getOrElse(deriver.deriveDynamic[G](metadata, doc, prependCombinedModifiers(modifiers, path, typeName)))
-            new Reflect.Dynamic(new BindingInstance(metadata, instance), typeName, doc, modifiers)
+            val instance = getCustomInstance[DynamicValue](path, TypeId.dynamicValue)
+              .getOrElse(deriver.deriveDynamic[G](metadata, doc, prependCombinedModifiers(modifiers, path, typeId)))
+            new Reflect.Dynamic(new BindingInstance(metadata, instance), typeId, doc, modifiers)
           }
 
           override def transformPrimitive[A0](
             path: DynamicOptic,
             primitiveType: PrimitiveType[A0],
-            typeName: TypeName[A0],
+            typeId: TypeId.OfType,
             metadata: F[BindingType.Primitive, A0],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect]
           ): Lazy[Reflect.Primitive[G, A0]] = Lazy {
-            val instance = getCustomInstance[A0](path, typeName).getOrElse(
+            val instance = getCustomInstance[A0](path, typeId).getOrElse(
               deriver
                 .derivePrimitive(
                   primitiveType,
-                  typeName,
+                  typeId,
                   metadata,
                   doc,
-                  prependCombinedModifiers(modifiers, path, typeName)
+                  prependCombinedModifiers(modifiers, path, typeId)
                 )
             )
-            new Reflect.Primitive(primitiveType, typeName, new BindingInstance(metadata, instance), doc, modifiers)
+            new Reflect.Primitive(primitiveType, typeId, new BindingInstance(metadata, instance), doc, modifiers)
           }
 
           override def transformWrapper[A0, B](
             path: DynamicOptic,
             wrapped: Reflect[G, B],
-            typeName: TypeName[A0],
+            typeId: TypeId.OfType,
             wrapperPrimitiveType: Option[PrimitiveType[A0]],
             metadata: F[BindingType.Wrapper[A0, B], A0],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect]
           ): Lazy[Reflect.Wrapper[G, A0, B]] = Lazy {
-            val instance = getCustomInstance[A0](path, typeName)
+            val instance = getCustomInstance[A0](path, typeId)
               .getOrElse(
                 deriver.deriveWrapper(
                   wrapped,
-                  typeName,
+                  typeId,
                   wrapperPrimitiveType,
                   metadata,
                   doc,
-                  prependCombinedModifiers(modifiers, path, typeName)
+                  prependCombinedModifiers(modifiers, path, typeId)
                 )
               )
             new Reflect.Wrapper(
               wrapped,
-              typeName,
+              typeId,
               wrapperPrimitiveType,
               new BindingInstance(metadata, instance),
               doc,

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/Deriver.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/Deriver.scala
@@ -12,7 +12,7 @@ trait Deriver[TC[_]] { self =>
 
   def derivePrimitive[F[_, _], A](
     primitiveType: PrimitiveType[A],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     binding: Binding[BindingType.Primitive, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
@@ -20,7 +20,7 @@ trait Deriver[TC[_]] { self =>
 
   def deriveRecord[F[_, _], A](
     fields: IndexedSeq[Term[F, A, ?]],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     binding: Binding[BindingType.Record, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
@@ -28,7 +28,7 @@ trait Deriver[TC[_]] { self =>
 
   def deriveVariant[F[_, _], A](
     cases: IndexedSeq[Term[F, A, ?]],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     binding: Binding[BindingType.Variant, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
@@ -36,7 +36,7 @@ trait Deriver[TC[_]] { self =>
 
   def deriveSequence[F[_, _], C[_], A](
     element: Reflect[F, A],
-    typeName: TypeName[C[A]],
+    typeId: TypeId.OfType,
     binding: Binding[BindingType.Seq[C], C[A]],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
@@ -45,7 +45,7 @@ trait Deriver[TC[_]] { self =>
   def deriveMap[F[_, _], M[_, _], K, V](
     key: Reflect[F, K],
     value: Reflect[F, V],
-    typeName: TypeName[M[K, V]],
+    typeId: TypeId.OfType,
     binding: Binding[BindingType.Map[M], M[K, V]],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
@@ -59,7 +59,7 @@ trait Deriver[TC[_]] { self =>
 
   def deriveWrapper[F[_, _], A, B](
     wrapped: Reflect[F, B],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     wrapperPrimitiveType: Option[PrimitiveType[A]],
     binding: Binding[BindingType.Wrapper[A, B], A],
     doc: Doc,

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/InstanceOverride.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/InstanceOverride.scala
@@ -6,4 +6,4 @@ sealed trait InstanceOverride
 
 case class InstanceOverrideByOptic[TC[_], A](optic: DynamicOptic, instance: Lazy[TC[A]]) extends InstanceOverride
 
-case class InstanceOverrideByType[TC[_], A](name: TypeName[A], instance: Lazy[TC[A]]) extends InstanceOverride
+case class InstanceOverrideByType[TC[_], A](typeId: TypeId.OfType, instance: Lazy[TC[A]]) extends InstanceOverride

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/ModifierOverride.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/ModifierOverride.scala
@@ -6,9 +6,9 @@ sealed trait ModifierOverride
 
 case class ModifierReflectOverrideByOptic(optic: DynamicOptic, modifier: Modifier.Reflect) extends ModifierOverride
 
-case class ModifierReflectOverrideByType[A](typeName: TypeName[A], modifier: Modifier.Reflect) extends ModifierOverride
+case class ModifierReflectOverrideByType[A](typeId: TypeId.OfType, modifier: Modifier.Reflect) extends ModifierOverride
 
-case class ModifierTermOverrideByType[A](typeName: TypeName[A], termName: String, modifier: Modifier.Term)
+case class ModifierTermOverrideByType[A](typeId: TypeId.OfType, termName: String, modifier: Modifier.Term)
     extends ModifierOverride
 
 case class ModifierTermOverrideByOptic[A](optic: DynamicOptic, termName: String, modifier: Modifier.Term)

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonBinaryCodecDeriver.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonBinaryCodecDeriver.scala
@@ -265,16 +265,16 @@ class JsonBinaryCodecDeriver private[json] (
 
   override def derivePrimitive[F[_, _], A](
     primitiveType: PrimitiveType[A],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     binding: Binding[BindingType.Primitive, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
   ): Lazy[JsonBinaryCodec[A]] =
-    Lazy(deriveCodec(new Reflect.Primitive(primitiveType, typeName, binding, doc, modifiers)))
+    Lazy(deriveCodec(new Reflect.Primitive(primitiveType, typeId, binding, doc, modifiers)))
 
   override def deriveRecord[F[_, _], A](
     fields: IndexedSeq[Term[F, A, ?]],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     binding: Binding[BindingType.Record, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
@@ -282,7 +282,7 @@ class JsonBinaryCodecDeriver private[json] (
     deriveCodec(
       new Reflect.Record(
         fields.asInstanceOf[IndexedSeq[Term[Binding, A, ?]]],
-        typeName,
+        typeId,
         binding,
         doc,
         modifiers
@@ -292,7 +292,7 @@ class JsonBinaryCodecDeriver private[json] (
 
   override def deriveVariant[F[_, _], A](
     cases: IndexedSeq[Term[F, A, ?]],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     binding: Binding[BindingType.Variant, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
@@ -300,7 +300,7 @@ class JsonBinaryCodecDeriver private[json] (
     deriveCodec(
       new Reflect.Variant(
         cases.asInstanceOf[IndexedSeq[Term[Binding, A, ? <: A]]],
-        typeName,
+        typeId,
         binding,
         doc,
         modifiers
@@ -310,20 +310,20 @@ class JsonBinaryCodecDeriver private[json] (
 
   override def deriveSequence[F[_, _], C[_], A](
     element: Reflect[F, A],
-    typeName: TypeName[C[A]],
+    typeId: TypeId.OfType,
     binding: Binding[BindingType.Seq[C], C[A]],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
   )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[JsonBinaryCodec[C[A]]] = Lazy {
     deriveCodec(
-      new Reflect.Sequence(element.asInstanceOf[Reflect[Binding, A]], typeName, binding, doc, modifiers)
+      new Reflect.Sequence(element.asInstanceOf[Reflect[Binding, A]], typeId, binding, doc, modifiers)
     )
   }
 
   override def deriveMap[F[_, _], M[_, _], K, V](
     key: Reflect[F, K],
     value: Reflect[F, V],
-    typeName: TypeName[M[K, V]],
+    typeId: TypeId.OfType,
     binding: Binding[BindingType.Map[M], M[K, V]],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
@@ -332,7 +332,7 @@ class JsonBinaryCodecDeriver private[json] (
       new Reflect.Map(
         key.asInstanceOf[Reflect[Binding, K]],
         value.asInstanceOf[Reflect[Binding, V]],
-        typeName,
+        typeId,
         binding,
         doc,
         modifiers
@@ -345,11 +345,11 @@ class JsonBinaryCodecDeriver private[json] (
     doc: Doc,
     modifiers: Seq[Modifier.Reflect]
   )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[JsonBinaryCodec[DynamicValue]] =
-    Lazy(deriveCodec(new Reflect.Dynamic(binding, TypeName.dynamicValue, doc, modifiers)))
+    Lazy(deriveCodec(new Reflect.Dynamic(binding, TypeId.dynamicValue, doc, modifiers)))
 
   def deriveWrapper[F[_, _], A, B](
     wrapped: Reflect[F, B],
-    typeName: TypeName[A],
+    typeId: TypeId.OfType,
     wrapperPrimitiveType: Option[PrimitiveType[A]],
     binding: Binding[BindingType.Wrapper[A, B], A],
     doc: Doc,
@@ -358,7 +358,7 @@ class JsonBinaryCodecDeriver private[json] (
     deriveCodec(
       new Reflect.Wrapper(
         wrapped.asInstanceOf[Reflect[Binding, B]],
-        typeName,
+        typeId,
         wrapperPrimitiveType,
         binding,
         doc,
@@ -380,8 +380,8 @@ class JsonBinaryCodecDeriver private[json] (
   type Map[_, _]
   type TC[_]
 
-  private[this] val recursiveRecordCache = new ThreadLocal[java.util.HashMap[TypeName[?], Array[FieldInfo]]] {
-    override def initialValue: java.util.HashMap[TypeName[?], Array[FieldInfo]] = new java.util.HashMap
+  private[this] val recursiveRecordCache = new ThreadLocal[java.util.HashMap[TypeIdRepr, Array[FieldInfo]]] {
+    override def initialValue: java.util.HashMap[TypeIdRepr, Array[FieldInfo]] = new java.util.HashMap
   }
   private[this] val discriminatorFields = new ThreadLocal[List[(String, String)]] {
     override def initialValue: List[(String, String)] = Nil
@@ -1980,16 +1980,16 @@ class JsonBinaryCodecDeriver private[json] (
           }
         } else {
           val isRecursive = fields.exists(_.value.isInstanceOf[Reflect.Deferred[F, ?]])
-          val typeName    = record.typeName
+          val typeId      = record.typeId
           var infos       =
-            if (isRecursive) recursiveRecordCache.get.get(typeName)
+            if (isRecursive) recursiveRecordCache.get.get(typeId)
             else null
           val deriveCodecs = infos eq null
           val map          = new StringToIntMap(len)
           var offset       = 0
           if (deriveCodecs) {
             infos = new Array[FieldInfo](len)
-            if (isRecursive) recursiveRecordCache.get.put(typeName, infos)
+            if (isRecursive) recursiveRecordCache.get.put(typeId, infos)
             discriminatorFields.set(null :: discriminatorFields.get)
           }
           var idx = 0
@@ -2419,10 +2419,10 @@ class JsonBinaryCodecDeriver private[json] (
     }
 
   private[this] def option[F[_, _], A](variant: Reflect.Variant[F, A]): Option[Reflect[F, ?]] = {
-    val typeName = variant.typeName
+    val typeId   = variant.typeId
     val cases    = variant.cases
     if (
-      typeName.namespace == Namespace.scala && typeName.name == "Option" &&
+      typeId.owner == Owner.fromNamespace(Namespace.scala) && typeId.name == "Option" &&
       cases.length == 2 && cases(1).name == "Some"
     ) cases(1).value.asRecord.map(_.fields(0).value)
     else None
@@ -2431,9 +2431,9 @@ class JsonBinaryCodecDeriver private[json] (
   private[this] def isOptional[F[_, _], A](reflect: Reflect[F, A]): Boolean =
     !requireOptionFields && reflect.isVariant && {
       val variant  = reflect.asVariant.get
-      val typeName = reflect.typeName
+      val typeId   = reflect.typeId
       val cases    = variant.cases
-      typeName.namespace == Namespace.scala && typeName.name == "Option" &&
+      typeId.owner == Owner.fromNamespace(Namespace.scala) && typeId.name == "Option" &&
       cases.length == 2 && cases(1).name == "Some"
     }
 
@@ -2461,8 +2461,8 @@ class JsonBinaryCodecDeriver private[json] (
       .discriminator
 
   private[this] def isTuple[F[_, _], A](reflect: Reflect[F, A]): Boolean = reflect.isRecord && {
-    val typeName = reflect.typeName
-    typeName.namespace == Namespace.scala && typeName.name.startsWith("Tuple")
+    val typeId = reflect.typeId
+    typeId.owner == Owner.fromNamespace(Namespace.scala) && typeId.name.startsWith("Tuple")
   }
 
   private[this] val dynamicValueCodec = new JsonBinaryCodec[DynamicValue]() {

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonBinaryCodecDeriver.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonBinaryCodecDeriver.scala
@@ -2419,8 +2419,8 @@ class JsonBinaryCodecDeriver private[json] (
     }
 
   private[this] def option[F[_, _], A](variant: Reflect.Variant[F, A]): Option[Reflect[F, ?]] = {
-    val typeId   = variant.typeId
-    val cases    = variant.cases
+    val typeId = variant.typeId
+    val cases  = variant.cases
     if (
       typeId.owner == Owner.fromNamespace(Namespace.scala) && typeId.name == "Option" &&
       cases.length == 2 && cases(1).name == "Some"
@@ -2430,9 +2430,9 @@ class JsonBinaryCodecDeriver private[json] (
 
   private[this] def isOptional[F[_, _], A](reflect: Reflect[F, A]): Boolean =
     !requireOptionFields && reflect.isVariant && {
-      val variant  = reflect.asVariant.get
-      val typeId   = reflect.typeId
-      val cases    = variant.cases
+      val variant = reflect.asVariant.get
+      val typeId  = reflect.typeId
+      val cases   = variant.cases
       typeId.owner == Owner.fromNamespace(Namespace.scala) && typeId.name == "Option" &&
       cases.length == 2 && cases(1).name == "Some"
     }

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
@@ -105,11 +105,13 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("_3"),
                   Schema[Long].reflect.asTerm("_4")
                 ),
-                typeId = TypeName.toTypeId(TypeName(
-                  namespace = Namespace(Seq("scala")),
-                  name = "Tuple4",
-                  params = Seq(TypeName.byte, TypeName.short, TypeName.int, TypeName.long)
-                )),
+                typeId = TypeName.toTypeId(
+                  TypeName(
+                    namespace = Namespace(Seq("scala")),
+                    name = "Tuple4",
+                    params = Seq(TypeName.byte, TypeName.short, TypeName.int, TypeName.long)
+                  )
+                ),
                 recordBinding = null
               )
             )
@@ -153,11 +155,13 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("_3"),
                   Schema[Long].reflect.asTerm("_4")
                 ),
-                typeId = TypeName.toTypeId(TypeName(
-                  namespace = Namespace(Seq("scala")),
-                  name = "Tuple4",
-                  params = Seq(TypeName.byte, TypeName.short, TypeName.int, TypeName.long)
-                )),
+                typeId = TypeName.toTypeId(
+                  TypeName(
+                    namespace = Namespace(Seq("scala")),
+                    name = "Tuple4",
+                    params = Seq(TypeName.byte, TypeName.short, TypeName.int, TypeName.long)
+                  )
+                ),
                 recordBinding = null
               )
             )
@@ -190,11 +194,13 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("_1"),
                   Schema[String].reflect.asTerm("_2")
                 ),
-                typeId = TypeName.toTypeId(TypeName(
-                  namespace = Namespace.scala,
-                  name = "Tuple2",
-                  params = Seq(TypeName.int, TypeName.string)
-                )),
+                typeId = TypeName.toTypeId(
+                  TypeName(
+                    namespace = Namespace.scala,
+                    name = "Tuple2",
+                    params = Seq(TypeName.int, TypeName.string)
+                  )
+                ),
                 recordBinding = null
               )
             )
@@ -215,14 +221,16 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema.derived[(Int, Long)].reflect.asTerm("_1"),
                   Schema.derived[(String, String)].reflect.asTerm("_2")
                 ),
-                typeId = TypeName.toTypeId(TypeName(
-                  namespace = Namespace.scala,
-                  name = "Tuple2",
-                  params = Seq(
-                    TypeName(Namespace.scala, "Tuple2", Seq(TypeName.int, TypeName.long)),
-                    TypeName(Namespace.scala, "Tuple2", Seq(TypeName.string, TypeName.string))
+                typeId = TypeName.toTypeId(
+                  TypeName(
+                    namespace = Namespace.scala,
+                    name = "Tuple2",
+                    params = Seq(
+                      TypeName(Namespace.scala, "Tuple2", Seq(TypeName.int, TypeName.long)),
+                      TypeName(Namespace.scala, "Tuple2", Seq(TypeName.string, TypeName.string))
+                    )
                   )
-                )),
+                ),
                 recordBinding = null
               )
             )
@@ -236,11 +244,13 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Option[Int]].reflect.asTerm("_1"),
                   Schema[Option[String]].reflect.asTerm("_2")
                 ),
-                typeId = TypeName.toTypeId(TypeName(
-                  namespace = Namespace.scala,
-                  name = "Tuple2",
-                  params = Seq(TypeName.option(TypeName.int), TypeName.option(TypeName.string))
-                )),
+                typeId = TypeName.toTypeId(
+                  TypeName(
+                    namespace = Namespace.scala,
+                    name = "Tuple2",
+                    params = Seq(TypeName.option(TypeName.int), TypeName.option(TypeName.string))
+                  )
+                ),
                 recordBinding = null
               )
             )

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
@@ -105,11 +105,11 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("_3"),
                   Schema[Long].reflect.asTerm("_4")
                 ),
-                typeName = TypeName(
+                typeId = TypeName.toTypeId(TypeName(
                   namespace = Namespace(Seq("scala")),
                   name = "Tuple4",
                   params = Seq(TypeName.byte, TypeName.short, TypeName.int, TypeName.long)
-                ),
+                )),
                 recordBinding = null
               )
             )
@@ -153,11 +153,11 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("_3"),
                   Schema[Long].reflect.asTerm("_4")
                 ),
-                typeName = TypeName(
+                typeId = TypeName.toTypeId(TypeName(
                   namespace = Namespace(Seq("scala")),
                   name = "Tuple4",
                   params = Seq(TypeName.byte, TypeName.short, TypeName.int, TypeName.long)
-                ),
+                )),
                 recordBinding = null
               )
             )
@@ -190,11 +190,11 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("_1"),
                   Schema[String].reflect.asTerm("_2")
                 ),
-                typeName = TypeName(
+                typeId = TypeName.toTypeId(TypeName(
                   namespace = Namespace.scala,
                   name = "Tuple2",
                   params = Seq(TypeName.int, TypeName.string)
-                ),
+                )),
                 recordBinding = null
               )
             )
@@ -215,14 +215,14 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema.derived[(Int, Long)].reflect.asTerm("_1"),
                   Schema.derived[(String, String)].reflect.asTerm("_2")
                 ),
-                typeName = TypeName(
+                typeId = TypeName.toTypeId(TypeName(
                   namespace = Namespace.scala,
                   name = "Tuple2",
                   params = Seq(
                     TypeName(Namespace.scala, "Tuple2", Seq(TypeName.int, TypeName.long)),
                     TypeName(Namespace.scala, "Tuple2", Seq(TypeName.string, TypeName.string))
                   )
-                ),
+                )),
                 recordBinding = null
               )
             )
@@ -236,11 +236,11 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Option[Int]].reflect.asTerm("_1"),
                   Schema[Option[String]].reflect.asTerm("_2")
                 ),
-                typeName = TypeName(
+                typeId = TypeName.toTypeId(TypeName(
                   namespace = Namespace.scala,
                   name = "Tuple2",
                   params = Seq(TypeName.option(TypeName.int), TypeName.option(TypeName.string))
-                ),
+                )),
                 recordBinding = null
               )
             )
@@ -251,7 +251,7 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
             new Schema[EmptyTuple](
               reflect = Reflect.Record[Binding, EmptyTuple](
                 fields = Vector(),
-                typeName = TypeName(Namespace(Seq("scala"), Seq("Tuple$package")), "EmptyTuple"),
+                typeId = TypeName.toTypeId(TypeName(Namespace(Seq("scala"), Seq("Tuple$package")), "EmptyTuple")),
                 recordBinding = null
               )
             )
@@ -303,7 +303,7 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                   Schema[Id].reflect.asTerm("id"),
                   Schema.derived[Value].reflect.asTerm("value")
                 ),
-                typeName = TypeName(Namespace.zioBlocksSchema, "Opaque"),
+                typeId = TypeName.toTypeId(TypeName(Namespace.zioBlocksSchema, "Opaque")),
                 recordBinding = null
               )
             )
@@ -352,7 +352,7 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
                     )
                     .asTerm("value")
                 ),
-                typeName = TypeName(Namespace.zioBlocksSchema, "InnerOpaque"),
+                typeId = TypeName.toTypeId(TypeName(Namespace.zioBlocksSchema, "InnerOpaque")),
                 recordBinding = null
               )
             )
@@ -981,7 +981,9 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
     implicit val schema: Schema[InnerId] = Schema(
       Reflect.Wrapper(
         wrapped = Reflect.string[Binding], // Cannot use `Schema[String].reflect` here
-        typeName = TypeName(Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaVersionSpecificSpec")), "InnerId"),
+        typeId = TypeName.toTypeId(
+          TypeName(Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaVersionSpecificSpec")), "InnerId")
+        ),
         wrapperPrimitiveType = Some(PrimitiveType.String(Validation.None)),
         wrapperBinding = Binding.Wrapper(s => InnerId(s), identity)
       )
@@ -1027,7 +1029,7 @@ object Id {
   implicit val schema: Schema[Id] = Schema(
     Reflect.Wrapper(
       wrapped = Reflect.string[Binding], // Cannot use `Schema[String].reflect` here
-      typeName = TypeName(Namespace.zioBlocksSchema, "Id"),
+      typeId = TypeName.toTypeId(TypeName(Namespace.zioBlocksSchema, "Id")),
       wrapperPrimitiveType = Some(PrimitiveType.String(Validation.None)),
       wrapperBinding = Binding.Wrapper(s => Id(s), identity)
     )

--- a/schema/shared/src/test/scala/zio/blocks/schema/OpticSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/OpticSpec.scala
@@ -3455,7 +3455,9 @@ object OpticSpecTypes {
 
     val reflect: Reflect.Wrapper[Binding, Wrapper, Record1] = new Reflect.Wrapper(
       wrapped = Schema[Record1].reflect,
-      typeName = TypeName(Namespace(Seq("zio", "blocks", "schema"), Seq("OpticSpec")), "Wrapper"),
+      typeId = TypeId.unsafeTag[TypeId.KindTag.Type](
+        new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "OpticSpec" :: Nil), "Wrapper", Nil)
+      ),
       wrapperPrimitiveType = None,
       wrapperBinding = Binding.Wrapper(
         wrap = Wrapper.apply,

--- a/schema/shared/src/test/scala/zio/blocks/schema/ReflectSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/ReflectSpec.scala
@@ -235,7 +235,9 @@ object ReflectSpec extends ZIOSpecDefault {
       test("has consistent equals and hashCode") {
         val record1 = tuple4Reflect
         val record2 = record1.copy(typeId =
-          TypeId.unsafeTag[TypeId.KindTag.Type](new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil), "Tuple4", Nil))
+          TypeId.unsafeTag[TypeId.KindTag.Type](
+            new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil), "Tuple4", Nil)
+          )
         )
         val record3 = record1.copy(fields = record1.fields.reverse)
         val record4 = record1.copy(doc = Doc("text"))
@@ -300,14 +302,22 @@ object ReflectSpec extends ZIOSpecDefault {
           tuple4Reflect
             .typeId(
               TypeId.unsafeTag[TypeId.KindTag.Type](
-                new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "Tuple4Wrapper", Nil)
+                new TypeIdRepr(
+                  new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil),
+                  "Tuple4Wrapper",
+                  Nil
+                )
               )
             )
             .typeId
         )(
           equalTo(
             TypeId.unsafeTag[TypeId.KindTag.Type](
-              new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "Tuple4Wrapper", Nil)
+              new TypeIdRepr(
+                new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil),
+                "Tuple4Wrapper",
+                Nil
+              )
             )
           )
         )
@@ -405,14 +415,22 @@ object ReflectSpec extends ZIOSpecDefault {
           eitherReflect
             .typeId(
               TypeId.unsafeTag[TypeId.KindTag.Type](
-                new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "EitherWrapper", Nil)
+                new TypeIdRepr(
+                  new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil),
+                  "EitherWrapper",
+                  Nil
+                )
               )
             )
             .typeId
         )(
           equalTo(
             TypeId.unsafeTag[TypeId.KindTag.Type](
-              new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "EitherWrapper", Nil)
+              new TypeIdRepr(
+                new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil),
+                "EitherWrapper",
+                Nil
+              )
             )
           )
         )
@@ -520,7 +538,7 @@ object ReflectSpec extends ZIOSpecDefault {
         )
       },
       test("gets and updates sequence type name") {
-        val sequence1 = Reflect.vector(Reflect.int[Binding])
+        val sequence1        = Reflect.vector(Reflect.int[Binding])
         val expectedVectorId =
           TypeId.unsafeTag[TypeId.KindTag.Type](
             new TypeIdRepr(
@@ -536,14 +554,22 @@ object ReflectSpec extends ZIOSpecDefault {
           sequence1
             .typeId(
               TypeId.unsafeTag[TypeId.KindTag.Type](
-                new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "VectorWrapper", Nil)
+                new TypeIdRepr(
+                  new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil),
+                  "VectorWrapper",
+                  Nil
+                )
               )
             )
             .typeId
         )(
           equalTo(
             TypeId.unsafeTag[TypeId.KindTag.Type](
-              new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "VectorWrapper", Nil)
+              new TypeIdRepr(
+                new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil),
+                "VectorWrapper",
+                Nil
+              )
             )
           )
         )
@@ -628,7 +654,7 @@ object ReflectSpec extends ZIOSpecDefault {
         )
       },
       test("gets and updates map type name") {
-        val map1 = Reflect.map(Reflect.int[Binding], Reflect.long[Binding])
+        val map1          = Reflect.map(Reflect.int[Binding], Reflect.long[Binding])
         val expectedMapId =
           TypeId.unsafeTag[TypeId.KindTag.Type](
             new TypeIdRepr(
@@ -732,14 +758,22 @@ object ReflectSpec extends ZIOSpecDefault {
           dynamic1
             .typeId(
               TypeId.unsafeTag[TypeId.KindTag.Type](
-                new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "DynamicWrapper", Nil)
+                new TypeIdRepr(
+                  new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil),
+                  "DynamicWrapper",
+                  Nil
+                )
               )
             )
             .typeId
         )(
           equalTo(
             TypeId.unsafeTag[TypeId.KindTag.Type](
-              new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "DynamicWrapper", Nil)
+              new TypeIdRepr(
+                new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil),
+                "DynamicWrapper",
+                Nil
+              )
             )
           )
         )
@@ -780,7 +814,9 @@ object ReflectSpec extends ZIOSpecDefault {
       test("has consistent equals and hashCode") {
         val wrapper1 = wrapperReflect
         val wrapper2 = wrapper1.copy(typeId =
-          TypeId.unsafeTag[TypeId.KindTag.Type](new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil), "Tuple4", Nil))
+          TypeId.unsafeTag[TypeId.KindTag.Type](
+            new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil), "Tuple4", Nil)
+          )
         )
         val wrapper3 = wrapper1.copy(wrapped = Reflect.long[Binding].doc("Long (updated)"))
         val wrapper4 = wrapper1.copy(doc = Doc("text"))
@@ -884,7 +920,11 @@ object ReflectSpec extends ZIOSpecDefault {
           deferred1
             .typeId(
               TypeId.unsafeTag[TypeId.KindTag.Type](
-                new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "YearWrapper", Nil)
+                new TypeIdRepr(
+                  new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil),
+                  "YearWrapper",
+                  Nil
+                )
               )
             )
             .typeId
@@ -951,10 +991,9 @@ object ReflectSpec extends ZIOSpecDefault {
     Schema.derived[Either[Int, Long]].reflect.asVariant.get
   val wrapperReflect: Reflect.Wrapper[Binding, Wrapper, Long] = new Reflect.Wrapper(
     wrapped = Schema[Long].reflect,
-    typeId =
-      TypeId.unsafeTag[TypeId.KindTag.Type](
-        new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "Wrapper", Nil)
-      ),
+    typeId = TypeId.unsafeTag[TypeId.KindTag.Type](
+      new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "Wrapper", Nil)
+    ),
     wrapperPrimitiveType = None,
     wrapperBinding = Binding.Wrapper(
       wrap = (x: Long) => Right(Wrapper(x)),

--- a/schema/shared/src/test/scala/zio/blocks/schema/ReflectSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/ReflectSpec.scala
@@ -150,10 +150,14 @@ object ReflectSpec extends ZIOSpecDefault {
         val long1 = Primitive[Binding, Long](
           primitiveType = PrimitiveType.Long(Validation.None),
           primitiveBinding = null, // should be ignored in equals and hashCode
-          typeName = TypeName.long
+          typeId = TypeId.long
         )
         val long2 = long1.copy(primitiveType = PrimitiveType.Long(Validation.Numeric.Positive))
-        val long3 = long1.copy(typeName = TypeName(Namespace(Seq("zio", "blocks", "schema")), "Long1"))
+        val long3 = long1.copy(typeId =
+          TypeId.unsafeTag[TypeId.KindTag.Type](
+            new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil), "Long1", Nil)
+          )
+        )
         val long4 = long1.copy(doc = Doc("text"))
         val long5 = long1.copy(modifiers = Seq(Modifier.config("key", "value")))
         assert(long1)(equalTo(long1)) &&
@@ -179,12 +183,22 @@ object ReflectSpec extends ZIOSpecDefault {
       },
       test("gets and updates primitive type name") {
         val int1 = Reflect.int[Binding]
-        assert(int1.typeName)(equalTo(TypeName.int)) &&
+        assert(int1.typeId)(equalTo(TypeId.int)) &&
         assert(
           int1
-            .typeName(TypeName(Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "IntWrapper"))
-            .typeName
-        )(equalTo(TypeName[Int](Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "IntWrapper")))
+            .typeId(
+              TypeId.unsafeTag[TypeId.KindTag.Type](
+                new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "IntWrapper", Nil)
+              )
+            )
+            .typeId
+        )(
+          equalTo(
+            TypeId.unsafeTag[TypeId.KindTag.Type](
+              new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "IntWrapper", Nil)
+            )
+          )
+        )
       },
       test("updates primitive default value") {
         val int1 = Reflect.int[Binding]
@@ -200,7 +214,7 @@ object ReflectSpec extends ZIOSpecDefault {
         val long1 = Primitive(
           primitiveType = PrimitiveType.Long(Validation.Numeric.Positive),
           primitiveBinding = Binding.Primitive[Long](examples = Seq(1L, 2L, 3L)),
-          typeName = TypeName.long,
+          typeId = TypeId.long,
           doc = Doc("Long (positive)")
         )
         assert(long1.examples)(equalTo(Seq(1L, 2L, 3L))) &&
@@ -220,7 +234,9 @@ object ReflectSpec extends ZIOSpecDefault {
     suite("Reflect.Record")(
       test("has consistent equals and hashCode") {
         val record1 = tuple4Reflect
-        val record2 = record1.copy(typeName = TypeName(Namespace(Seq("zio", "blocks", "schema")), "Tuple4"))
+        val record2 = record1.copy(typeId =
+          TypeId.unsafeTag[TypeId.KindTag.Type](new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil), "Tuple4", Nil))
+        )
         val record3 = record1.copy(fields = record1.fields.reverse)
         val record4 = record1.copy(doc = Doc("text"))
         val record5 = record1.copy(modifiers = Seq(Modifier.config("key", "value")))
@@ -265,24 +281,33 @@ object ReflectSpec extends ZIOSpecDefault {
         )
       },
       test("gets and updates record type name") {
-        assert(tuple4Reflect.typeName)(
-          equalTo(
-            TypeName[(Byte, Short, Int, Long)](
-              Namespace.scala,
+        val expectedTuple4Id =
+          TypeId.unsafeTag[TypeId.KindTag.Type](
+            new TypeIdRepr(
+              Owner.fromNamespace(Namespace.scala),
               "Tuple4",
-              Seq(TypeName.byte, TypeName.short, TypeName.int, TypeName.long)
+              new TypeParam(TypeId.byte) :: new TypeParam(TypeId.short) :: new TypeParam(TypeId.int) :: new TypeParam(
+                TypeId.long
+              ) :: Nil
             )
+          )
+        assert(tuple4Reflect.typeId)(
+          equalTo(
+            expectedTuple4Id
           )
         ) &&
         assert(
           tuple4Reflect
-            .typeName(TypeName(Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "Tuple4Wrapper"))
-            .typeName
+            .typeId(
+              TypeId.unsafeTag[TypeId.KindTag.Type](
+                new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "Tuple4Wrapper", Nil)
+              )
+            )
+            .typeId
         )(
           equalTo(
-            TypeName[(Byte, Short, Int, Long)](
-              Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")),
-              "Tuple4Wrapper"
+            TypeId.unsafeTag[TypeId.KindTag.Type](
+              new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "Tuple4Wrapper", Nil)
             )
           )
         )
@@ -363,18 +388,32 @@ object ReflectSpec extends ZIOSpecDefault {
         assert(eitherReflect.fromDynamicValue(eitherReflect.toDynamicValue(Left(0))))(isRight(equalTo(Left(0))))
       },
       test("gets and updates variant type name") {
-        assert(eitherReflect.typeName)(
+        val expectedEitherId =
+          TypeId.unsafeTag[TypeId.KindTag.Type](
+            new TypeIdRepr(
+              new Owner("scala" :: "util" :: Nil),
+              "Either",
+              new TypeParam(TypeId.int) :: new TypeParam(TypeId.long) :: Nil
+            )
+          )
+        assert(eitherReflect.typeId)(
           equalTo(
-            TypeName[Either[Int, Long]](Namespace(Seq("scala", "util")), "Either", Seq(TypeName.int, TypeName.long))
+            expectedEitherId
           )
         ) &&
         assert(
           eitherReflect
-            .typeName(TypeName(Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "EitherWrapper"))
-            .typeName
+            .typeId(
+              TypeId.unsafeTag[TypeId.KindTag.Type](
+                new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "EitherWrapper", Nil)
+              )
+            )
+            .typeId
         )(
           equalTo(
-            TypeName[Either[Int, Long]](Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "EitherWrapper")
+            TypeId.unsafeTag[TypeId.KindTag.Type](
+              new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "EitherWrapper", Nil)
+            )
           )
         )
       },
@@ -430,13 +469,15 @@ object ReflectSpec extends ZIOSpecDefault {
       test("has consistent equals and hashCode") {
         val sequence1 = Reflect.Sequence[Binding, Double, List](
           element = Reflect.double,
-          typeName = TypeName.list(TypeName.double),
+          typeId = TypeId.list(TypeId.double),
           seqBinding = null // should be ignored in equals and hashCode
         )
         val sequence2 = sequence1.copy(element =
-          Primitive(PrimitiveType.Double(Validation.None), TypeName.double, Binding.Primitive.double, Doc("text"))
+          Primitive(PrimitiveType.Double(Validation.None), TypeId.double, Binding.Primitive.double, Doc("text"))
         )
-        val sequence3 = sequence1.copy(typeName = TypeName[List[Double]](Namespace.scala, "List2"))
+        val sequence3 = sequence1.copy(typeId =
+          TypeId.unsafeTag[TypeId.KindTag.Type](new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "List2", Nil))
+        )
         val sequence4 = sequence1.copy(doc = Doc("text"))
         val sequence5 = sequence1.copy(modifiers = Seq(Modifier.config("key", "value")))
         assert(sequence1)(equalTo(sequence1)) &&
@@ -480,16 +521,30 @@ object ReflectSpec extends ZIOSpecDefault {
       },
       test("gets and updates sequence type name") {
         val sequence1 = Reflect.vector(Reflect.int[Binding])
-        assert(sequence1.typeName)(
-          equalTo(TypeName[Vector[Int]](Namespace.scalaCollectionImmutable, "Vector", Seq(TypeName.int)))
+        val expectedVectorId =
+          TypeId.unsafeTag[TypeId.KindTag.Type](
+            new TypeIdRepr(
+              Owner.fromNamespace(Namespace.scalaCollectionImmutable),
+              "Vector",
+              new TypeParam(TypeId.int) :: Nil
+            )
+          )
+        assert(sequence1.typeId)(
+          equalTo(expectedVectorId)
         ) &&
         assert(
           sequence1
-            .typeName(TypeName(Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "VectorWrapper"))
-            .typeName
+            .typeId(
+              TypeId.unsafeTag[TypeId.KindTag.Type](
+                new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "VectorWrapper", Nil)
+              )
+            )
+            .typeId
         )(
           equalTo(
-            TypeName[Vector[Int]](Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "VectorWrapper")
+            TypeId.unsafeTag[TypeId.KindTag.Type](
+              new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "VectorWrapper", Nil)
+            )
           )
         )
       },
@@ -506,7 +561,7 @@ object ReflectSpec extends ZIOSpecDefault {
       test("gets and updates sequence examples") {
         val sequence1 = Reflect.Sequence[Binding, Double, List](
           element = Reflect.double,
-          typeName = TypeName.list(TypeName.double),
+          typeId = TypeId.list(TypeId.double),
           seqBinding = Binding.Seq[List, Double](
             constructor = SeqConstructor.listConstructor,
             deconstructor = SeqDeconstructor.listDeconstructor,
@@ -532,20 +587,22 @@ object ReflectSpec extends ZIOSpecDefault {
         val map1 = Reflect.Map[Binding, Short, Float, Map](
           key = Reflect.short,
           value = Reflect.float,
-          typeName = TypeName.map(TypeName.short, TypeName.float),
+          typeId = TypeId.map(TypeId.short, TypeId.float),
           mapBinding = null // should be ignored in equals and hashCode
         )
         val map2 = map1.copy(key =
           Primitive(
             PrimitiveType.Short(Validation.Numeric.Positive),
-            TypeName.short,
+            TypeId.short,
             Binding.Primitive.short
           )
         )
         val map3 = map1.copy(value =
-          Primitive(PrimitiveType.Float(Validation.None), TypeName.float, Binding.Primitive.float, Doc("text"))
+          Primitive(PrimitiveType.Float(Validation.None), TypeId.float, Binding.Primitive.float, Doc("text"))
         )
-        val map4 = map1.copy(typeName = TypeName[Map[Short, Float]](Namespace.scala, "Map2"))
+        val map4 = map1.copy(typeId =
+          TypeId.unsafeTag[TypeId.KindTag.Type](new TypeIdRepr(Owner.fromNamespace(Namespace.scala), "Map2", Nil))
+        )
         val map5 = map1.copy(doc = Doc("text"))
         val map6 = map1.copy(modifiers = Seq(Modifier.config("key", "value")))
         assert(map1)(equalTo(map1)) &&
@@ -572,16 +629,28 @@ object ReflectSpec extends ZIOSpecDefault {
       },
       test("gets and updates map type name") {
         val map1 = Reflect.map(Reflect.int[Binding], Reflect.long[Binding])
-        assert(map1.typeName)(
-          equalTo(TypeName[Map[Int, Long]](Namespace.scalaCollectionImmutable, "Map", Seq(TypeName.int, TypeName.long)))
-        ) &&
+        val expectedMapId =
+          TypeId.unsafeTag[TypeId.KindTag.Type](
+            new TypeIdRepr(
+              Owner.fromNamespace(Namespace.scalaCollectionImmutable),
+              "Map",
+              new TypeParam(TypeId.int) :: new TypeParam(TypeId.long) :: Nil
+            )
+          )
+        assert(map1.typeId)(equalTo(expectedMapId)) &&
         assert(
           map1
-            .typeName(TypeName(Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "MapWrapper"))
-            .typeName
+            .typeId(
+              TypeId.unsafeTag[TypeId.KindTag.Type](
+                new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "MapWrapper", Nil)
+              )
+            )
+            .typeId
         )(
           equalTo(
-            TypeName[Map[Int, Long]](Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "MapWrapper")
+            TypeId.unsafeTag[TypeId.KindTag.Type](
+              new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "MapWrapper", Nil)
+            )
           )
         )
       },
@@ -594,7 +663,7 @@ object ReflectSpec extends ZIOSpecDefault {
         val map1 = Reflect.Map[Binding, Int, Long, Map](
           key = Reflect.int,
           value = Reflect.long,
-          typeName = TypeName.map(TypeName.int, TypeName.long),
+          typeId = TypeId.map(TypeId.int, TypeId.long),
           mapBinding = null, // should be ignored in equals and hashCode
           doc = Doc("Map of Int to Long")
         )
@@ -607,7 +676,7 @@ object ReflectSpec extends ZIOSpecDefault {
         val map1 = Reflect.Map[Binding, Int, Long, Map](
           key = Reflect.int,
           value = Reflect.long,
-          typeName = TypeName.map(TypeName.int, TypeName.long),
+          typeId = TypeId.map(TypeId.int, TypeId.long),
           mapBinding = Binding.Map[Map, Int, Long](
             constructor = MapConstructor.map,
             deconstructor = MapDeconstructor.map,
@@ -658,14 +727,20 @@ object ReflectSpec extends ZIOSpecDefault {
       },
       test("gets and updates dynamic type name") {
         val dynamic1 = Reflect.dynamic[Binding]
-        assert(dynamic1.typeName)(equalTo(TypeName.dynamicValue)) &&
+        assert(dynamic1.typeId)(equalTo(TypeId.dynamicValue)) &&
         assert(
           dynamic1
-            .typeName(TypeName(Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "DynamicWrapper"))
-            .typeName
+            .typeId(
+              TypeId.unsafeTag[TypeId.KindTag.Type](
+                new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "DynamicWrapper", Nil)
+              )
+            )
+            .typeId
         )(
           equalTo(
-            TypeName[DynamicValue](Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "DynamicWrapper")
+            TypeId.unsafeTag[TypeId.KindTag.Type](
+              new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "DynamicWrapper", Nil)
+            )
           )
         )
       },
@@ -704,7 +779,9 @@ object ReflectSpec extends ZIOSpecDefault {
     suite("Reflect.Wrapper")(
       test("has consistent equals and hashCode") {
         val wrapper1 = wrapperReflect
-        val wrapper2 = wrapper1.copy(typeName = TypeName(Namespace(Seq("zio", "blocks", "schema")), "Tuple4"))
+        val wrapper2 = wrapper1.copy(typeId =
+          TypeId.unsafeTag[TypeId.KindTag.Type](new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil), "Tuple4", Nil))
+        )
         val wrapper3 = wrapper1.copy(wrapped = Reflect.long[Binding].doc("Long (updated)"))
         val wrapper4 = wrapper1.copy(doc = Doc("text"))
         val wrapper5 = wrapper1.copy(modifiers = Seq(Modifier.config("key", "value")))
@@ -727,14 +804,28 @@ object ReflectSpec extends ZIOSpecDefault {
         )
       },
       test("gets and updates wrapper type name") {
-        assert(wrapperReflect.typeName)(
-          equalTo(TypeName[Wrapper](Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "Wrapper"))
+        val expectedWrapperId =
+          TypeId.unsafeTag[TypeId.KindTag.Type](
+            new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "Wrapper", Nil)
+          )
+        assert(wrapperReflect.typeId)(
+          equalTo(expectedWrapperId)
         ) &&
         assert(
           wrapperReflect
-            .typeName(TypeName(Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "Wrapper2"))
-            .typeName
-        )(equalTo(TypeName[Wrapper](Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "Wrapper2")))
+            .typeId(
+              TypeId.unsafeTag[TypeId.KindTag.Type](
+                new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "Wrapper2", Nil)
+              )
+            )
+            .typeId
+        )(
+          equalTo(
+            TypeId.unsafeTag[TypeId.KindTag.Type](
+              new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "Wrapper2", Nil)
+            )
+          )
+        )
       },
       test("gets and updates wrapper default value") {
         assert(wrapperReflect.getDefaultValue)(isNone) &&
@@ -763,7 +854,7 @@ object ReflectSpec extends ZIOSpecDefault {
         val deferred1 = Reflect.Deferred[Binding, Int](() => Reflect.int)
         val deferred2 = Reflect.Deferred[Binding, Int](() => Reflect.int)
         val deferred3 = Reflect.int[Binding]
-        val deferred4 = Primitive(PrimitiveType.Int(Validation.Numeric.Positive), TypeName.int, Binding.Primitive.int)
+        val deferred4 = Primitive(PrimitiveType.Int(Validation.Numeric.Positive), TypeId.int, Binding.Primitive.int)
         val deferred5 = Reflect.Deferred[Binding, Int](() => deferred4)
         assert(deferred1)(equalTo(deferred1)) &&
         assert(deferred1.hashCode)(equalTo(deferred1.hashCode)) &&
@@ -786,14 +877,24 @@ object ReflectSpec extends ZIOSpecDefault {
         val deferred1 = Reflect.Deferred[Binding, Year](() => Reflect.year)
         assert(deferred1.fromDynamicValue(deferred1.toDynamicValue(Year.of(2025))))(isRight(equalTo(Year.of(2025))))
       },
-      test("gets and updates deferred type name") {
+      test("gets and updates deferred type id") {
         val deferred1 = Reflect.Deferred[Binding, Year](() => Reflect.year)
-        assert(deferred1.typeName)(equalTo(TypeName.year)) &&
+        assert(deferred1.typeId)(equalTo(TypeId.year)) &&
         assert(
           deferred1
-            .typeName(TypeName(Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "YearWrapper"))
-            .typeName
-        )(equalTo(TypeName[Year](Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "YearWrapper")))
+            .typeId(
+              TypeId.unsafeTag[TypeId.KindTag.Type](
+                new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "YearWrapper", Nil)
+              )
+            )
+            .typeId
+        )(
+          equalTo(
+            TypeId.unsafeTag[TypeId.KindTag.Type](
+              new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "YearWrapper", Nil)
+            )
+          )
+        )
       },
       test("gets and updates deferred default value") {
         val deferred1 = Reflect.Deferred[Binding, YearMonth](() => Reflect.yearMonth)
@@ -839,7 +940,7 @@ object ReflectSpec extends ZIOSpecDefault {
         assert(deferred1.isMap)(equalTo(false)) &&
         assert(deferred1.asWrapperUnknown)(isNone) &&
         assert(deferred1.isWrapper)(equalTo(false)) &&
-        assert(deferred1.typeName)(equalTo(null))
+        assert(deferred1.typeId)(equalTo(null))
       }
     )
   )
@@ -850,7 +951,10 @@ object ReflectSpec extends ZIOSpecDefault {
     Schema.derived[Either[Int, Long]].reflect.asVariant.get
   val wrapperReflect: Reflect.Wrapper[Binding, Wrapper, Long] = new Reflect.Wrapper(
     wrapped = Schema[Long].reflect,
-    typeName = TypeName(Namespace(Seq("zio", "blocks", "schema"), Seq("ReflectSpec")), "Wrapper"),
+    typeId =
+      TypeId.unsafeTag[TypeId.KindTag.Type](
+        new TypeIdRepr(new Owner("zio" :: "blocks" :: "schema" :: Nil, "ReflectSpec" :: Nil), "Wrapper", Nil)
+      ),
     wrapperPrimitiveType = None,
     wrapperBinding = Binding.Wrapper(
       wrap = (x: Long) => Right(Wrapper(x)),

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
@@ -14,6 +14,11 @@ import java.nio.CharBuffer
 import scala.collection.immutable.ArraySeq
 
 object SchemaSpec extends ZIOSpecDefault {
+  private def tid(namespace: Namespace, name: String, params: Seq[TypeIdRepr] = Nil): TypeId.OfType =
+    TypeId.unsafeTag[TypeId.KindTag.Type](
+      new TypeIdRepr(Owner.fromNamespace(namespace), name, params.toList.map(new TypeParam(_)))
+    )
+
   def spec: Spec[TestEnvironment, Any] = suite("SchemaSpec")(
     suite("Reflect.Primitive")(
       test("has consistent equals and hashCode") {
@@ -162,11 +167,7 @@ object SchemaSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("_3"),
                   Schema[Long].reflect.asTerm("_4")
                 ),
-                typeName = TypeName(
-                  namespace = Namespace(Seq("scala")),
-                  name = "Tuple4",
-                  params = Seq(TypeName.byte, TypeName.short, TypeName.int, TypeName.long)
-                ),
+                typeId = tid(Namespace(Seq("scala")), "Tuple4", Seq(TypeId.byte, TypeId.short, TypeId.int, TypeId.long)),
                 recordBinding = null
               )
             )
@@ -219,10 +220,7 @@ object SchemaSpec extends ZIOSpecDefault {
                     ),
                   Schema[Float].reflect.asTerm("f-2").copy(modifiers = Seq(Modifier.transient()))
                 ),
-                typeName = TypeName(
-                  namespace = Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
-                  name = "Record-1"
-                ),
+                typeId = tid(Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")), "Record-1"),
                 recordBinding = null,
                 modifiers = Seq(
                   Modifier.config("record-key", "record-value-1"),
@@ -268,10 +266,10 @@ object SchemaSpec extends ZIOSpecDefault {
                   Schema[Byte].reflect.asTerm("b"),
                   Schema[Int].reflect.asTerm("i")
                 ),
-                typeName = TypeName(
-                  namespace = Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
-                  name = "Record-2",
-                  params = Seq(TypeName.byte, TypeName.int)
+                typeId = tid(
+                  Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
+                  "Record-2",
+                  Seq(TypeId.byte, TypeId.int)
                 ),
                 recordBinding = null
               )
@@ -308,10 +306,7 @@ object SchemaSpec extends ZIOSpecDefault {
                   Schema[Short].reflect.asTerm("s"),
                   Schema[Long].reflect.asTerm("l")
                 ),
-                typeName = TypeName(
-                  namespace = Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
-                  name = "Record3"
-                ),
+                typeId = tid(Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")), "Record3"),
                 recordBinding = null
               )
             )
@@ -356,10 +351,7 @@ object SchemaSpec extends ZIOSpecDefault {
                   Schema[Vector[ArraySeq[Int]]].reflect.asTerm("mx"),
                   Schema[List[Set[Int]]].reflect.asTerm("rs")
                 ),
-                typeName = TypeName(
-                  namespace = Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
-                  name = "Record4"
-                ),
+                typeId = tid(Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")), "Record4"),
                 recordBinding = null
               )
             )
@@ -420,10 +412,7 @@ object SchemaSpec extends ZIOSpecDefault {
                   Schema[Unit].reflect.asTerm("u"),
                   Schema[Seq[Unit]].reflect.asTerm("su")
                 ),
-                typeName = TypeName(
-                  namespace = Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
-                  name = "Record5"
-                ),
+                typeId = tid(Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")), "Record5"),
                 recordBinding = null
               )
             )
@@ -559,10 +548,7 @@ object SchemaSpec extends ZIOSpecDefault {
                   Schema[Option[DynamicValue]].reflect.asTerm("od"),
                   Schema[IndexedSeq[DynamicValue]].reflect.asTerm("isd")
                 ),
-                typeName = TypeName(
-                  namespace = Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
-                  name = "Record7"
-                ),
+                typeId = tid(Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")), "Record7"),
                 recordBinding = null
               )
             )
@@ -577,13 +563,13 @@ object SchemaSpec extends ZIOSpecDefault {
         val value  = Record8[Option](Some(1), Some(Record8[Option](Some(2), None)))
         assert(record.map(_.constructor.usedRegisters))(isSome(equalTo(RegisterOffset(objects = 2)))) &&
         assert(record.map(_.deconstructor.usedRegisters))(isSome(equalTo(RegisterOffset(objects = 2)))) &&
-        assert(record.map(_.typeName))(
+        assert(record.map(_.typeId))(
           isSome(
             equalTo(
-              TypeName[Record8[Option]](
-                namespace = Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
-                name = "Record8",
-                params = Seq(TypeName(Namespace.scala, "Option"))
+              tid(
+                Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
+                "Record8",
+                Seq(tid(Namespace.scala, "Option"))
               )
             )
           )
@@ -691,7 +677,7 @@ object SchemaSpec extends ZIOSpecDefault {
           new Schema(
             new Reflect.Wrapper[Binding, Chunk[V], List[V]](
               Schema.list[V].reflect,
-              TypeName(Namespace(Seq("zio")), "Chunk"),
+              tid(Namespace(Seq("zio")), "Chunk"),
               None,
               new Binding.Wrapper(x => new Right(Chunk.fromIterable(x)), _.toList)
             )
@@ -938,13 +924,10 @@ object SchemaSpec extends ZIOSpecDefault {
           isRight(equalTo(`Case-3`))
         ) &&
         assert(variant.map(_.cases.map(_.name)))(isSome(equalTo(Vector("Case-1", "Case-2", "Case-3")))) &&
-        assert(variant.map(_.typeName))(
+        assert(variant.map(_.typeId))(
           isSome(
             equalTo(
-              TypeName[`Variant-1`](
-                namespace = Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
-                name = "Variant-1"
-              )
+              tid(Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")), "Variant-1")
             )
           )
         ) &&
@@ -994,14 +977,10 @@ object SchemaSpec extends ZIOSpecDefault {
           isRight(equalTo(Value[String]("WWW")))
         ) &&
         assert(variant.map(_.cases.map(_.name)))(isSome(equalTo(Vector("MissingValue", "NullValue", "Value")))) &&
-        assert(variant.map(_.typeName))(
+        assert(variant.map(_.typeId))(
           isSome(
             equalTo(
-              TypeName[`Variant-2`[String]](
-                namespace = Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
-                name = "Variant-2",
-                params = Seq(TypeName.string)
-              )
+              tid(Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")), "Variant-2", Seq(TypeId.string))
             )
           )
         )
@@ -1048,21 +1027,18 @@ object SchemaSpec extends ZIOSpecDefault {
         assert(schema1.fromDynamicValue(schema1.toDynamicValue(B.A1)))(isRight(equalTo(B.A1))) &&
         assert(schema1.fromDynamicValue(schema1.toDynamicValue(B.A2)))(isRight(equalTo(B.A2))) &&
         assert(variant1.map(_.cases.map(_.name)))(isSome(equalTo(Vector("A1", "A2")))) &&
-        assert(variant1.map(_.typeName))(
-          isSome(equalTo(TypeName[A](Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec")), "A")))
+        assert(variant1.map(_.typeId))(
+          isSome(equalTo(tid(Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec")), "A")))
         ) &&
         assert(Level1_MultiLevel.c.getOption(Case))(isSome(equalTo(Case))) &&
         assert(Level1_MultiLevel.l1_c.getOption(Level1.Case))(isSome(equalTo(Level1.Case))) &&
         assert(schema2.fromDynamicValue(schema2.toDynamicValue(Case)))(isRight(equalTo(Case))) &&
         assert(schema2.fromDynamicValue(schema2.toDynamicValue(Level1.Case)))(isRight(equalTo(Level1.Case))) &&
         assert(variant2.map(_.cases.map(_.name)))(isSome(equalTo(Vector("Level1.Case", "Case")))) &&
-        assert(variant2.map(_.typeName))(
+        assert(variant2.map(_.typeId))(
           isSome(
             equalTo(
-              TypeName[Level1.MultiLevel](
-                namespace = Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "Level1")),
-                name = "MultiLevel"
-              )
+              tid(Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "Level1")), "MultiLevel")
             )
           )
         )
@@ -1094,13 +1070,13 @@ object SchemaSpec extends ZIOSpecDefault {
           isRight(equalTo(`Case-2`[Option](None)))
         ) &&
         assert(variant.map(_.cases.map(_.name)))(isSome(equalTo(Vector("Case-1", "Case-2")))) &&
-        assert(variant.map(_.typeName))(
+        assert(variant.map(_.typeId))(
           isSome(
             equalTo(
-              TypeName[`Variant-3`[Option]](
-                namespace = Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
-                name = "Variant-3",
-                params = Seq(TypeName(Namespace.scala, "Option"))
+              tid(
+                Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
+                "Variant-3",
+                Seq(tid(Namespace.scala, "Option"))
               )
             )
           )
@@ -1120,13 +1096,13 @@ object SchemaSpec extends ZIOSpecDefault {
         val schema  = Schema.derived[Variant4[String, Int]]
         val variant = schema.reflect.asVariant
         assert(variant.map(_.cases.map(_.name)))(isSome(equalTo(Vector("Error", "Fatal", "Success", "Timeout")))) &&
-        assert(variant.map(_.typeName))(
+        assert(variant.map(_.typeId))(
           isSome(
             equalTo(
-              TypeName[Variant4[String, Int]](
-                namespace = Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
-                name = "Variant4",
-                params = Seq(TypeName.string, TypeName.int)
+              tid(
+                Namespace(Seq("zio", "blocks", "schema"), Seq("SchemaSpec", "spec")),
+                "Variant4",
+                Seq(TypeId.string, TypeId.int)
               )
             )
           )
@@ -1384,7 +1360,7 @@ object SchemaSpec extends ZIOSpecDefault {
         val map1 = Reflect.Map[Binding, Int, Long, Map](
           key = Reflect.int,
           value = Reflect.long,
-          typeName = TypeName.map(TypeName.int, TypeName.long),
+          typeId = TypeId.map(TypeId.int, TypeId.long),
           mapBinding = Binding.Map[Map, Int, Long](
             constructor = MapConstructor.map,
             deconstructor = MapDeconstructor.map,
@@ -1525,7 +1501,7 @@ object SchemaSpec extends ZIOSpecDefault {
         val deferred1 = Reflect.Deferred[Binding, Int](() => Reflect.int)
         val deferred2 = Reflect.Deferred[Binding, Int](() => Reflect.int)
         val deferred3 = Reflect.int[Binding]
-        val deferred4 = Primitive(PrimitiveType.Int(Validation.Numeric.Positive), TypeName.int, Binding.Primitive.int)
+        val deferred4 = Primitive(PrimitiveType.Int(Validation.Numeric.Positive), TypeId.int, Binding.Primitive.int)
         val deferred5 = Reflect.Deferred[Binding, Int](() => deferred4)
         assert(Schema(deferred1))(equalTo(Schema(deferred1))) &&
         assert(Schema(deferred1).hashCode)(equalTo(Schema(deferred1).hashCode)) &&
@@ -1550,7 +1526,7 @@ object SchemaSpec extends ZIOSpecDefault {
         val deferred1 = Reflect.Deferred[Binding, Int] { () =>
           Primitive(
             PrimitiveType.Int(Validation.Numeric.Positive),
-            TypeName.int,
+            TypeId.int,
             Binding.Primitive(examples = Seq(1, 2, 3))
           )
         }
@@ -1894,7 +1870,7 @@ object SchemaSpec extends ZIOSpecDefault {
         new Deriver[TextCodec] {
           override def derivePrimitive[F[_, _], A](
             primitiveType: PrimitiveType[A],
-            typeName: TypeName[A],
+            typeId: TypeId.OfType,
             binding: Binding[BindingType.Primitive, A],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect]
@@ -1907,7 +1883,7 @@ object SchemaSpec extends ZIOSpecDefault {
 
           override def deriveRecord[F[_, _], A](
             fields: IndexedSeq[Term[F, A, ?]],
-            typeName: TypeName[A],
+            typeId: TypeId.OfType,
             binding: Binding[BindingType.Record, A],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect]
@@ -1920,7 +1896,7 @@ object SchemaSpec extends ZIOSpecDefault {
 
           override def deriveVariant[F[_, _], A](
             cases: IndexedSeq[Term[F, A, ?]],
-            typeName: TypeName[A],
+            typeId: TypeId.OfType,
             binding: Binding[BindingType.Variant, A],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect]
@@ -1933,7 +1909,7 @@ object SchemaSpec extends ZIOSpecDefault {
 
           override def deriveSequence[F[_, _], C[_], A](
             element: Reflect[F, A],
-            typeName: TypeName[C[A]],
+            typeId: TypeId.OfType,
             binding: Binding[BindingType.Seq[C], C[A]],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect]
@@ -1947,7 +1923,7 @@ object SchemaSpec extends ZIOSpecDefault {
           override def deriveMap[F[_, _], M[_, _], K, V](
             key: Reflect[F, K],
             value: Reflect[F, V],
-            typeName: TypeName[M[K, V]],
+            typeId: TypeId.OfType,
             binding: Binding[BindingType.Map[M], M[K, V]],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect]
@@ -1974,7 +1950,7 @@ object SchemaSpec extends ZIOSpecDefault {
 
           override def deriveWrapper[F[_, _], A, B](
             wrapped: Reflect[F, B],
-            typeName: TypeName[A],
+            typeId: TypeId.OfType,
             wrapperPrimitiveType: Option[PrimitiveType[A]],
             binding: Binding[BindingType.Wrapper[A, B], A],
             doc: Doc,

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
@@ -167,7 +167,8 @@ object SchemaSpec extends ZIOSpecDefault {
                   Schema[Int].reflect.asTerm("_3"),
                   Schema[Long].reflect.asTerm("_4")
                 ),
-                typeId = tid(Namespace(Seq("scala")), "Tuple4", Seq(TypeId.byte, TypeId.short, TypeId.int, TypeId.long)),
+                typeId =
+                  tid(Namespace(Seq("scala")), "Tuple4", Seq(TypeId.byte, TypeId.short, TypeId.int, TypeId.long)),
                 recordBinding = null
               )
             )

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonBinaryCodecDeriverSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonBinaryCodecDeriverSpec.scala
@@ -1841,7 +1841,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
           .derived[Tuple10[Unit, Boolean, Byte, Short, Int, Long, Float, Double, Char, String]]
           .deriving(JsonBinaryCodecDeriver)
           .instance(
-            TypeName.boolean,
+            TypeId.boolean,
             new JsonBinaryCodec[Boolean](JsonBinaryCodec.booleanType) { // stringifies boolean values
               def decodeValue(in: JsonReader, default: Boolean): Boolean = in.readStringAsBoolean()
 
@@ -1849,7 +1849,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
             }
           )
           .instance(
-            TypeName.byte,
+            TypeId.byte,
             new JsonBinaryCodec[Byte](JsonBinaryCodec.byteType) { // stringifies byte values
               def decodeValue(in: JsonReader, default: Byte): Byte = in.readStringAsByte()
 
@@ -1857,7 +1857,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
             }
           )
           .instance(
-            TypeName.short,
+            TypeId.short,
             new JsonBinaryCodec[Short](JsonBinaryCodec.shortType) { // stringifies short values
               def decodeValue(in: JsonReader, default: Short): Short = in.readStringAsShort()
 
@@ -1865,7 +1865,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
             }
           )
           .instance(
-            TypeName.int,
+            TypeId.int,
             new JsonBinaryCodec[Int](JsonBinaryCodec.intType) { // stringifies int values
               def decodeValue(in: JsonReader, default: Int): Int = in.readStringAsInt()
 
@@ -1873,7 +1873,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
             }
           )
           .instance(
-            TypeName.long,
+            TypeId.long,
             new JsonBinaryCodec[Long](JsonBinaryCodec.longType) { // stringifies long values
               def decodeValue(in: JsonReader, default: Long): Long = in.readStringAsLong()
 
@@ -1881,7 +1881,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
             }
           )
           .instance(
-            TypeName.float,
+            TypeId.float,
             new JsonBinaryCodec[Float](JsonBinaryCodec.floatType) { // stringifies float values
               def decodeValue(in: JsonReader, default: Float): Float = in.readStringAsFloat()
 
@@ -1889,7 +1889,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
             }
           )
           .instance(
-            TypeName.double,
+            TypeId.double,
             new JsonBinaryCodec[Double](JsonBinaryCodec.doubleType) { // stringifies double values
               def decodeValue(in: JsonReader, default: Double): Double = in.readStringAsDouble()
 
@@ -1897,7 +1897,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
             }
           )
           .instance(
-            TypeName.char,
+            TypeId.char,
             new JsonBinaryCodec[Char](JsonBinaryCodec.charType) { // expecting char code numbers (not one-char strings)
               def decodeValue(in: JsonReader, default: Char): Char = in.readInt().toChar
 
@@ -1915,7 +1915,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
         val codec = Record3.schema
           .deriving(JsonBinaryCodecDeriver)
           .instance(
-            TypeName.currency,
+            TypeId.currency,
             new JsonBinaryCodec[Currency]() { // decode null values as the default one ("USD")
               def decodeValue(in: JsonReader, default: Currency): Currency =
                 if (in.isNextToken('n')) {
@@ -2025,7 +2025,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
         val codec = Record2.schema
           .deriving(JsonBinaryCodecDeriver)
           .instance(
-            TypeName.int,
+            TypeId.int,
             new JsonBinaryCodec[Int](JsonBinaryCodec.intType) { // stringifies int values
               def decodeValue(in: JsonReader, default: Int): Int = in.readStringAsInt()
 
@@ -2054,7 +2054,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
         val codec = Record2.schema
           .deriving(JsonBinaryCodecDeriver)
           .instance(
-            Record1.schema.reflect.typeName,
+            Record1.schema.reflect.typeId,
             new JsonBinaryCodec[Record1]() { // allows null values which are prohibited for codecs derived by default
               private val codec = Record1.schema.derive(JsonBinaryCodecDeriver)
 
@@ -2220,7 +2220,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
           .derived[Array[Boolean]]
           .deriving(JsonBinaryCodecDeriver)
           .instance(
-            TypeName.boolean,
+            TypeId.boolean,
             new JsonBinaryCodec[Boolean](JsonBinaryCodec.booleanType) { // stringifies boolean values
               def decodeValue(in: JsonReader, default: Boolean): Boolean = in.readStringAsBoolean()
 
@@ -2232,7 +2232,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
           .derived[Array[Byte]]
           .deriving(JsonBinaryCodecDeriver)
           .instance(
-            TypeName.byte,
+            TypeId.byte,
             new JsonBinaryCodec[Byte](JsonBinaryCodec.byteType) { // stringifies byte values
               def decodeValue(in: JsonReader, default: Byte): Byte = in.readStringAsByte()
 
@@ -2244,7 +2244,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
           .derived[Array[Char]]
           .deriving(JsonBinaryCodecDeriver)
           .instance(
-            TypeName.char,
+            TypeId.char,
             new JsonBinaryCodec[Char](JsonBinaryCodec.charType) { // char values as numbers
               def decodeValue(in: JsonReader, default: Char): Char = in.readInt().toChar
 
@@ -2256,7 +2256,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
           .derived[Array[Short]]
           .deriving(JsonBinaryCodecDeriver)
           .instance(
-            TypeName.short,
+            TypeId.short,
             new JsonBinaryCodec[Short](JsonBinaryCodec.shortType) { // stringifies short values
               def decodeValue(in: JsonReader, default: Short): Short = in.readStringAsShort()
 
@@ -2268,7 +2268,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
           .derived[Array[Int]]
           .deriving(JsonBinaryCodecDeriver)
           .instance(
-            TypeName.int,
+            TypeId.int,
             new JsonBinaryCodec[Int](JsonBinaryCodec.intType) { // stringifies int values
               def decodeValue(in: JsonReader, default: Int): Int = in.readStringAsInt()
 
@@ -2280,7 +2280,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
           .derived[Array[Float]]
           .deriving(JsonBinaryCodecDeriver)
           .instance(
-            TypeName.float,
+            TypeId.float,
             new JsonBinaryCodec[Float](JsonBinaryCodec.floatType) { // stringifies float values
               def decodeValue(in: JsonReader, default: Float): Float = in.readStringAsFloat()
 
@@ -2292,7 +2292,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
           .derived[Array[Long]]
           .deriving(JsonBinaryCodecDeriver)
           .instance(
-            TypeName.long,
+            TypeId.long,
             new JsonBinaryCodec[Long](JsonBinaryCodec.longType) { // stringifies long values
               def decodeValue(in: JsonReader, default: Long): Long = in.readStringAsLong()
 
@@ -2304,7 +2304,7 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
           .derived[Array[Double]]
           .deriving(JsonBinaryCodecDeriver)
           .instance(
-            TypeName.double,
+            TypeId.double,
             new JsonBinaryCodec[Double](JsonBinaryCodec.doubleType) { // stringifies double values
               def decodeValue(in: JsonReader, default: Double): Double = in.readStringAsDouble()
 
@@ -3022,7 +3022,13 @@ object JsonBinaryCodecDeriverSpec extends ZIOSpecDefault {
     implicit val schema: Schema[Email] = new Schema(
       new Reflect.Wrapper[Binding, Email, String](
         Schema[String].reflect,
-        TypeName(Namespace(Seq("zio", "blocks", "schema", "json"), Seq("JsonBinaryCodecDeriverSpec")), "Email"),
+        TypeId.unsafeTag[TypeId.KindTag.Type](
+          new TypeIdRepr(
+            new Owner("zio" :: "blocks" :: "schema" :: "json" :: Nil, "JsonBinaryCodecDeriverSpec" :: Nil),
+            "Email",
+            Nil
+          )
+        ),
         None,
         new Binding.Wrapper(
           {


### PR DESCRIPTION
Replaces the `TypeName` system with a new, principled `TypeId` system for robust type identification across Scala 2 and 3.

The new `TypeId` system uses a runtime `TypeIdRepr` tagged with a phantom type to correctly model types and type constructors, support arbitrary arity in Scala 3, and avoid leaking Scala 3 concepts. This change provides a more extensible and robust foundation, with a compatibility layer for existing `TypeName` usages.

---
<a href="https://cursor.com/background-agent?bcId=bc-23485050-63dd-4f6a-a67b-cf08fec93192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23485050-63dd-4f6a-a67b-cf08fec93192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

